### PR TITLE
Fix bug where Fxx speed and tempo effects slow down playback

### DIFF
--- a/BambooTracker/tick_counter.cpp
+++ b/BambooTracker/tick_counter.cpp
@@ -138,11 +138,13 @@ void TickCounter::resetRest()
 		tickDiffSum_ += tickDiff_;
 		int castedTickDifSum = static_cast<int>(tickDiffSum_);
 		restTickToNextStep_ = defStepSize_ + castedTickDifSum;
-		if (restTickToNextStep_ < 1) restTickToNextStep_ = 1;	// Prevent wait count changing to 0 (freeze)
 		tickDiffSum_ -= castedTickDifSum;
 	}
 	else {
 		restTickToNextStep_ = grooves_.at(static_cast<size_t>(nextGroovePos_));
 		nextGroovePos_ = (nextGroovePos_ + 1) % static_cast<int>(grooves_.size());
 	}
+
+	// Ensure each row lasts for at least 1 tick, and that we can subtract 1 safely.
+	if (restTickToNextStep_ < 1) restTickToNextStep_ = 1;
 }

--- a/BambooTracker/tick_counter.cpp
+++ b/BambooTracker/tick_counter.cpp
@@ -92,6 +92,12 @@ void TickCounter::setGrooveState(GrooveState state)
 		resetRest();
 		break;
 	}
+
+	// When enabling groove (which disables tempo), reset tempo accumulator.
+	if (state == GrooveState::ValidByGlobal || state == GrooveState::ValidByLocal) {
+		tickDiffSum_ = 0.f;
+		prevTickDiffSum_ = 0.f;
+	}
 }
 
 bool TickCounter::getGrooveEnabled() const noexcept

--- a/BambooTracker/tick_counter.cpp
+++ b/BambooTracker/tick_counter.cpp
@@ -83,7 +83,6 @@ void TickCounter::setGrooveState(GrooveState state)
 	case GrooveState::ValidByLocal:
 		nextGroovePos_ = 0;
 		resetRest();
-		--restTickToNextStep_;	// Count down by step head
 		break;
 	case GrooveState::Invalid:
 		nextGroovePos_ = -1;
@@ -110,8 +109,9 @@ int TickCounter::countUp()
 		if (!restTickToNextStep_) {  // When head of step, calculate real step size
 			resetRest();
 		}
-
-		--restTickToNextStep_;   // Count down to next step
+		else {
+			--restTickToNextStep_;	 // Count down to next step
+		}
 
 		return ret;
 	}
@@ -147,4 +147,10 @@ void TickCounter::resetRest()
 
 	// Ensure each row lasts for at least 1 tick, and that we can subtract 1 safely.
 	if (restTickToNextStep_ < 1) restTickToNextStep_ = 1;
+
+	// If resetRest() is called in response to the tracker processing a row or Fxx/Oxx event,
+	// subtract 1 so countUp() will remain on the row for (speed - 1) subsequent ticks.
+	if (isPlaySong_) {
+		restTickToNextStep_--;
+	}
 }

--- a/BambooTracker/tick_counter.cpp
+++ b/BambooTracker/tick_counter.cpp
@@ -80,8 +80,8 @@ void TickCounter::setGrooveState(GrooveState state)
 {
 	switch (state) {
 	case GrooveState::ValidByGlobal:
-		nextGroovePos_ = static_cast<int>(grooves_.size()) - 1;
-		resetRest();
+		nextGroovePos_ = 0;
+		if (isPlaySong_) restTickToNextStep_ = grooves_.at(0) - 1;
 		break;
 	case GrooveState::ValidByLocal:
 		nextGroovePos_ = 0;

--- a/BambooTracker/tick_counter.hpp
+++ b/BambooTracker/tick_counter.hpp
@@ -68,6 +68,7 @@ private:
 
 	float tickDiff_;
 	float tickDiffSum_;
+	float prevTickDiffSum_;
 
 	void updateTickDifference();
 	void resetRest();


### PR DESCRIPTION
Code review walkthrough (pointing out non-obvious reasoning, arguable decisions, questions, and further issues I found):

## Fixing one-tick delay

I changed `resetRest()` to decrement `restTickToNextStep_` when the song is playing, to fix the one-tick delay issue (#383). As a result, `TickCounter::setGrooveState(GrooveState::ValidByLocal)` now only decrements restTickToNextStep_ if the song is playing. If the song is not playing (eg. "retrieve channel state"), it doesn't do so (whereas it used to). I don't *think* this has any observable effect. I didn't find any uses of `ValidByLocal` outside of playback and "retrieve channel state", but it's possible I missed something.

Also, `TickCounter::setGrooveState(GrooveState::ValidByGlobal)` (adjusting the song-global speed spinbox) now decrements restTickToNextStep_ while the song is playing (it used to never). I don't know if it makes a significant difference.

**BUG:** Both the GUI thread (changing speed spinbox) and audio thread (Fxx effect) call `TickCounter::setSpeed` without synchronization (the audio thread `PlaybackManager::streamCountUp()` acquires `PlaybackManager::mutex_` but the UI `QObject::connect(ui->speedSpinBox` doesn't). Additionally the GUI thread calling `TickCounter::setSpeed` can collide with the audio thread calling other TickCounter methods. This is a data race with undefined behavior, and can lead to unpredictable bugs.

## Fixing tempo delay

I also changed `resetRest()` to compute `tickDiffSum_` based off a cached `prevTickDiffSum_` from the most recent `countUp()` call, so that multiple calls to `resetRest()` on the same row will always produce the same result even if a tempo is active (unless a groove is active). I hope I properly assigned and reset `prevTickDiffSum_`.

To preserve the tempo state across `Fxx` tempo effects, I changed `setTempo()` to not set `tickDiffSum_` to 0. In my testing, this didn't produce issues (like rows taking too long or too short of a time) when switching between fast and slow tempos, and didn't sound wrong in my own music either. I didn't think about the code long enough to see if my changes could lead to incorrectly calculated `restTickToNextStep_`, but I didn't notice any issues using the program, and `if (restTickToNextStep_ < 1) restTickToNextStep_ = 1;` should prevent bad things from happening.

I also changed `setSpeed()` to not set `tickDiffSum_` to 0 (a debatable choice). This is because in BambooTracker and FamiTracker, changing speed doesn't cause previously set tempo to stop taking effect, so I decided to not reset the tempo state either. However this has the downside that you can't reset the tempo accumulator mid-song using a speed command.

- Perhaps setGrooveState should reset `tickDiffSum_` and `prevTickDiffSum_`, since in BambooTracker, groove and tempo are mutually exclusive. I didn't make this change, but I could add it.

## Misc

I explicitly initialized all fields in `TickCounter::TickCounter()`. I wanted to initialize `prevTickDiffSum_` upfront because I didn't know when it would otherwise be initialized, and decided to initialize the other fields as well. I don't like leaving uninitialized fields around, since they're a landmine that creates problems if you later unknowingly change the code to read an uninitialized variable.

- I actually don't like the look of the initializer list I wrote, since it's both verbose and easy to forget to initialize fields. I'd kinda prefer to put the initializers in the header file (like `bool isPlaySong_ = false`), but decided against it since it didn't make sense to put `tempo_ = 150` in the header file. Honestly I think the presence of a default tempo, tick rate, and step size at all is a code smell; the initial values should be explicitly passed into the constructor. I don't like how the default tempo of 150 is duplicated in the .ui file, song.hpp, *and* tick_counter.cpp.

----

An earlier draft of this PR introduced a new variable `shouldTickRest_` set to true in `countUp()` and false in `resetCount()`, and read by `resetRest()`. However I messed it up; it should only be set to true if `isPlaySong_` was true, and it introduced another moving part that I might've failed to set and unset at the right times. I decided to remove `shouldTickRest_` altogether and use `isPlaySong_` as a substitute. This is simpler, but I don't know if it's correct either. **Will this cause any problems?**

**Question:** Why does `GrooveState::ValidByGlobal` initialize nextGroovePos_ to size - 1? Is it OK if I change both GrooveState values to decrement `restTickToNextStep_` if the song is playing?

----

(Sidenote) I'm having some trouble reasoning about this code, the order of events across multiple files, and I don't know what methods are called in what order, but I do know that the order affects how the code acts. I feel ["John Carmack on Inlined Code"][1] is a good argument against tangled codebases with deeply nested control flow.

[1]: http://number-none.com/blow/john_carmack_on_inlined_code.html

Fixes #376.
Fixes #383.