### PR TITLE
Fix missing translations

### DIFF
--- a/BambooTracker/gui/configuration_dialog.cpp
+++ b/BambooTracker/gui/configuration_dialog.cpp
@@ -63,8 +63,9 @@ inline bool fromCheckState(Qt::CheckState state)
 
 struct NotationSystemAttribute
 {
-	QString name, dispName;
-	NoteNotationSystem ev;
+	const QString name;
+	const char* dispName;
+	const NoteNotationSystem ev;
 };
 
 const NotationSystemAttribute NOTATION_SYSS[] = {
@@ -149,7 +150,7 @@ ConfigurationDialog::ConfigurationDialog(std::weak_ptr<Configuration> config, st
 	{
 		QSignalBlocker blocker(ui->noteNameComboBox);
 		for (const auto& attrib : NOTATION_SYSS) {
-			ui->noteNameComboBox->addItem(attrib.dispName);
+			ui->noteNameComboBox->addItem(QCoreApplication::translate("NotationSystem", attrib.dispName));
 			if (attrib.ev == configLocked->getNotationSystem()) {
 				ui->noteNameComboBox->setCurrentIndex(ui->noteNameComboBox->count() - 1);
 			}

--- a/BambooTracker/gui/effect_description.cpp
+++ b/BambooTracker/gui/effect_description.cpp
@@ -25,6 +25,7 @@
 
 #include "effect_description.hpp"
 #include <unordered_map>
+#include <QCoreApplication>
 #include "enum_hash.hpp"
 
 namespace effect_desc
@@ -35,8 +36,6 @@ struct EffectDetail
 {
 	const QString format;
 	const char* desc;
-
-	QString mergedString() const { return format + " - " + desc; }
 };
 
 const std::unordered_map<EffectType, EffectDetail> DETAILS = {
@@ -89,12 +88,16 @@ QString getEffectFormat(const EffectType type)
 }
 QString getEffectDescription(const EffectType type)
 {
-	return DETAILS.at(type).desc;
+	return QCoreApplication::translate("EffectDescription", DETAILS.at(type).desc);
 }
 
 QString getEffectFormatAndDetailString(const EffectType type)
 {
-	if (type == EffectType::NoEffect) return DETAILS.at(EffectType::NoEffect).desc;
-	else return DETAILS.at(type).mergedString();
+	if (type == EffectType::NoEffect) {
+		return getEffectDescription(EffectType::NoEffect);
+	}
+	else {
+		return getEffectFormat(type) + " - " + getEffectDescription(type);
+	}
 }
 }

--- a/BambooTracker/gui/file_io_error_message_box.cpp
+++ b/BambooTracker/gui/file_io_error_message_box.cpp
@@ -25,10 +25,11 @@
 
 #include "file_io_error_message_box.hpp"
 #include <QMessageBox>
+#include <QCoreApplication>
 
 namespace
 {
-const std::unordered_map<io::FileType, QString> FILE_NAMES = {
+const std::unordered_map<io::FileType, const char*> FILE_NAMES = {
 	{ io::FileType::Mod, QT_TRANSLATE_NOOP("FileType", "module") },
 	{ io::FileType::S98, QT_TRANSLATE_NOOP("FileType", "s98") },
 	{ io::FileType::VGM, QT_TRANSLATE_NOOP("FileType", "vgm") },
@@ -48,7 +49,7 @@ FileIOErrorMessageBox::FileIOErrorMessageBox(const QString& file, bool isInput, 
 	: parent_(parent)
 {
 	const io::FileIOError *err = &e;
-	QString type = FILE_NAMES.at(err->fileType());
+	QString type = QCoreApplication::translate("FileType", FILE_NAMES.at(err->fileType()));
 
 	if (dynamic_cast<const io::FileNotExistError*>(err)) {
 		desc_ = tr("Path does not exist.");

--- a/BambooTracker/gui/instrument_editor/instrument_editor_drumkit_form.cpp
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_drumkit_form.cpp
@@ -26,6 +26,7 @@
 #include "instrument_editor_drumkit_form.hpp"
 #include "ui_instrument_editor_drumkit_form.h"
 #include <QString>
+#include <QCoreApplication>
 #include "instrument.hpp"
 #include "note.hpp"
 #include "gui/event_guard.hpp"
@@ -36,7 +37,7 @@
 
 namespace
 {
-const QString PAN_TEXT[] = {
+const char* PAN_TEXT[] = {
 	QT_TRANSLATE_NOOP("Panning", "Left"),
 	QT_TRANSLATE_NOOP("Panning", "Center"),
 	QT_TRANSLATE_NOOP("Panning", "Right")
@@ -91,7 +92,7 @@ InstrumentEditorDrumkitForm::InstrumentEditorDrumkitForm(int num, QWidget *paren
 	//========== Pan ==========//
 	ui->panHorizontalSlider->setStyle(new SliderStyle);
 	ui->panHorizontalSlider->installEventFilter(this);
-	ui->panPosLabel->setText(PAN_TEXT[ui->panHorizontalSlider->value()]);
+	ui->panPosLabel->setText(QCoreApplication::translate("Panning", PAN_TEXT[ui->panHorizontalSlider->value()]));
 }
 
 InstrumentEditorDrumkitForm::~InstrumentEditorDrumkitForm()
@@ -249,7 +250,7 @@ void InstrumentEditorDrumkitForm::on_pitchSpinBox_valueChanged(int arg1)
 //--- Pan
 void InstrumentEditorDrumkitForm::on_panHorizontalSlider_valueChanged(int value)
 {
-	const QString text = PAN_TEXT[value];
+	const QString text = QCoreApplication::translate("Panning", PAN_TEXT[value]);
 	ui->panPosLabel->setText(text);
 
 	int key = ui->keyTreeWidget->currentIndex().row();
@@ -279,7 +280,7 @@ void InstrumentEditorDrumkitForm::setInstrumentSampleParameters(int key)
 					instKit->getRawSample(key));
 		item->setText(1, QString::number(sampNum));
 		item->setText(2, QString::number(instKit->getPitch(key)));
-		item->setText(3, PAN_TEXT[convertPanInternalToUi(instKit->getPan(key))]);
+		item->setText(3, QCoreApplication::translate("Panning", PAN_TEXT[convertPanInternalToUi(instKit->getPan(key))]));
 	}
 	else {
 		ui->sampleEditor->setInstrumentSampleParameters(

--- a/BambooTracker/gui/module_properties_dialog.cpp
+++ b/BambooTracker/gui/module_properties_dialog.cpp
@@ -28,12 +28,13 @@
 #include <vector>
 #include <utility>
 #include <unordered_map>
+#include <QCoreApplication>
 #include "gui/gui_utils.hpp"
 #include "enum_hash.hpp"
 
 namespace
 {
-const std::unordered_map<SongType, QString> SONG_TYPE_TEXT = {
+const std::unordered_map<SongType, const char*> SONG_TYPE_TEXT = {
 	{ SongType::Standard, QT_TRANSLATE_NOOP("SongType", "Standard") },
 	{ SongType::FM3chExpanded, QT_TRANSLATE_NOOP("SongType", "FM3ch expanded") }
 };
@@ -76,8 +77,8 @@ ModulePropertiesDialog::ModulePropertiesDialog(std::weak_ptr<BambooTracker> core
 		insertSong(i, gui_utils::utf8ToQString(title), core.lock()->getSongStyle(i).type, i);
 	}
 
-	ui->sngTypeComboBox->addItem(SONG_TYPE_TEXT.at(SongType::Standard), static_cast<int>(SongType::Standard));
-	ui->sngTypeComboBox->addItem(SONG_TYPE_TEXT.at(SongType::FM3chExpanded), static_cast<int>(SongType::FM3chExpanded));
+	ui->sngTypeComboBox->addItem(QCoreApplication::translate("SongType", SONG_TYPE_TEXT.at(SongType::Standard)), static_cast<int>(SongType::Standard));
+	ui->sngTypeComboBox->addItem(QCoreApplication::translate("SongType", SONG_TYPE_TEXT.at(SongType::FM3chExpanded)), static_cast<int>(SongType::FM3chExpanded));
 }
 
 ModulePropertiesDialog::~ModulePropertiesDialog()

--- a/BambooTracker/lang/bamboo_tracker_fr.ts
+++ b/BambooTracker/lang/bamboo_tracker_fr.ts
@@ -242,7 +242,7 @@
     <name>ConfigurationDialog</name>
     <message>
         <location filename="../gui/configuration_dialog.ui" line="14"/>
-        <location filename="../gui/configuration_dialog.cpp" line="499"/>
+        <location filename="../gui/configuration_dialog.cpp" line="500"/>
         <source>Configuration</source>
         <translation>Configuration</translation>
     </message>
@@ -677,22 +677,22 @@
         <translation type="vanished">Touches spéciales</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="163"/>
+        <location filename="../gui/configuration_dialog.cpp" line="164"/>
         <source>Key off</source>
         <translation>Relâchement de touche</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="164"/>
+        <location filename="../gui/configuration_dialog.cpp" line="165"/>
         <source>Octave up</source>
         <translation>Octave supérieure</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="165"/>
+        <location filename="../gui/configuration_dialog.cpp" line="166"/>
         <source>Octave down</source>
         <translation>Octave inférieure</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="166"/>
+        <location filename="../gui/configuration_dialog.cpp" line="167"/>
         <source>Echo buffer</source>
         <translation>Tampon d&apos;écho</translation>
     </message>
@@ -901,28 +901,28 @@
         <translation>Réinitialiser</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="584"/>
+        <location filename="../gui/configuration_dialog.cpp" line="585"/>
         <source>Virtual port</source>
         <translation>Port virtuel</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="360"/>
+        <location filename="../gui/configuration_dialog.cpp" line="361"/>
         <source>Master</source>
         <translation>Maître</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="499"/>
+        <location filename="../gui/configuration_dialog.cpp" line="500"/>
         <source>The change of emulator will be effective after restarting the program.</source>
         <translation>Le changement d&apos;émulateur sera pris en compte au redémarrage du logiciel.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="102"/>
+        <location filename="../gui/configuration_dialog.cpp" line="103"/>
         <source>Warp the cursor around the edges of the pattern editor.</source>
         <translatorcomment>J&apos;ai rien trouvé de mieux.</translatorcomment>
         <translation type="unfinished">Le curseur se déplace de manière cyclique à proximité des bords de l&apos;éditeur de motifs.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="104"/>
+        <location filename="../gui/configuration_dialog.cpp" line="105"/>
         <source>Move to previous or next order when reaching top or bottom in the pattern editor.</source>
         <translatorcomment>Incertitude à propos de la traduction adéquate pour &quot;order&quot;</translatorcomment>
         <translation type="unfinished">Se positionner sur l&apos;ordre précédent ou suivant lorsque le sommet ou le bas de l&apos;éditeur de motifs est atteint.</translation>
@@ -933,48 +933,48 @@
         <translation type="obsolete">Afficher le numéro d&apos;ordre et le nombre d&apos;ordres en hexadécimal dans la barre d&apos;état.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="106"/>
+        <location filename="../gui/configuration_dialog.cpp" line="107"/>
         <source>Display row numbers and the playback position on the status bar in hexadecimal.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="108"/>
+        <location filename="../gui/configuration_dialog.cpp" line="109"/>
         <source>Preview previous and next orders in the pattern editor.</source>
         <translatorcomment>Incertitude à propos de la traduction adéquate pour &quot;order&quot;</translatorcomment>
         <translation type="unfinished">Prévisualiser les ordres précédent et suivant dans l&apos;éditeur de motifs.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="110"/>
+        <location filename="../gui/configuration_dialog.cpp" line="111"/>
         <source>Create a backup copy of the existing file when saving a module.</source>
         <translation>Créer une copie de sauvegarde du fichier existant lors de la sauvegarde d&apos;un module.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="112"/>
+        <location filename="../gui/configuration_dialog.cpp" line="113"/>
         <source>Don&apos;t select the whole track when double-clicking in the pattern editor.</source>
         <translation>Ne pas sélectionner la piste entière lors d&apos;un double-clic dans l&apos;éditeur de motif.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="114"/>
+        <location filename="../gui/configuration_dialog.cpp" line="115"/>
         <source>Reverse the order of FM volume so that 00 is the quietest in the pattern editor.</source>
         <translation>Inverser la valeur du volume FM pour que 00 soit le plus bas dans l&apos;éditeur de motif.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="116"/>
+        <location filename="../gui/configuration_dialog.cpp" line="117"/>
         <source>Move the cursor to right after entering effects in the pattern editor.</source>
         <translation>Déplacer le curseur vers la droite après être entré dans les effets dans l&apos;éditeur de motif.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="118"/>
+        <location filename="../gui/configuration_dialog.cpp" line="119"/>
         <source>Reconstruct the current channel&apos;s state from previous orders upon playing.</source>
         <translation>Reconstruire l&apos;état du canal actuel à partir des ordres précédents durant la lecture.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="120"/>
+        <location filename="../gui/configuration_dialog.cpp" line="121"/>
         <source>Translate to your language from the next launch. See readme to check supported languages.</source>
         <translation>Traduire en votre langue au prochain démarrage. Lire le fichier readme pour connaître la liste des langues gérées.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="122"/>
+        <location filename="../gui/configuration_dialog.cpp" line="123"/>
         <source>Display FM detune values as signed numbers in the FM envelope editor.</source>
         <translation>Afficher les valeurs de désaccordage FM comme nombres signés dans l&apos;éditeur d&apos;enveloppe FM.</translation>
     </message>
@@ -983,382 +983,382 @@
         <translation type="vanished">Activer un oscilloscope qui affiche la forme d&apos;onde du signal de sortie.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="124"/>
+        <location filename="../gui/configuration_dialog.cpp" line="125"/>
         <source>Fill 00 to effect value column upon entering effect id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="126"/>
+        <location filename="../gui/configuration_dialog.cpp" line="127"/>
         <source>Move the cursor position by cell with horizontal scroll bar in the order list and the pattern editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="128"/>
+        <location filename="../gui/configuration_dialog.cpp" line="129"/>
         <source>Overwrite unused and unedited instrument properties on creating new properties. When disabled, override unused properties regardless of editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="131"/>
+        <location filename="../gui/configuration_dialog.cpp" line="132"/>
         <source>Send only ADPCM samples used by instruments to the ADPCM memory. Recommend to turn off if you change ADPCM samples frequently due to take the high rewriting cost.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="134"/>
+        <location filename="../gui/configuration_dialog.cpp" line="135"/>
         <source>Correspond the instrument number in patterns when the instrument changes its number.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="136"/>
+        <location filename="../gui/configuration_dialog.cpp" line="137"/>
         <source>Set maximum volume during jam mode. When unchecked, the volume is changed by the volume spinbox.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="138"/>
+        <location filename="../gui/configuration_dialog.cpp" line="139"/>
         <source>Mute hidden tracks when visibility of tracks is changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="140"/>
+        <location filename="../gui/configuration_dialog.cpp" line="141"/>
         <source>Restore the previous track visibility on startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="167"/>
+        <location filename="../gui/configuration_dialog.cpp" line="168"/>
         <source>Play and stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="168"/>
+        <location filename="../gui/configuration_dialog.cpp" line="169"/>
         <source>Play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="169"/>
+        <location filename="../gui/configuration_dialog.cpp" line="170"/>
         <source>Play from start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="170"/>
+        <location filename="../gui/configuration_dialog.cpp" line="171"/>
         <source>Play pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="171"/>
+        <location filename="../gui/configuration_dialog.cpp" line="172"/>
         <source>Play from cursor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="172"/>
+        <location filename="../gui/configuration_dialog.cpp" line="173"/>
         <source>Play from marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="173"/>
+        <location filename="../gui/configuration_dialog.cpp" line="174"/>
         <source>Play step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="174"/>
+        <location filename="../gui/configuration_dialog.cpp" line="175"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="175"/>
+        <location filename="../gui/configuration_dialog.cpp" line="176"/>
         <source>Focus on pattern editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="176"/>
+        <location filename="../gui/configuration_dialog.cpp" line="177"/>
         <source>Focus on order list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="177"/>
+        <location filename="../gui/configuration_dialog.cpp" line="178"/>
         <source>Focus on instrument list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="178"/>
+        <location filename="../gui/configuration_dialog.cpp" line="179"/>
         <source>Toggle edit/jam mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="179"/>
+        <location filename="../gui/configuration_dialog.cpp" line="180"/>
         <source>Set marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="180"/>
+        <location filename="../gui/configuration_dialog.cpp" line="181"/>
         <source>Paste and mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="181"/>
+        <location filename="../gui/configuration_dialog.cpp" line="182"/>
         <source>Paste and overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="182"/>
+        <location filename="../gui/configuration_dialog.cpp" line="183"/>
         <source>Paste and insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="183"/>
+        <location filename="../gui/configuration_dialog.cpp" line="184"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="184"/>
+        <location filename="../gui/configuration_dialog.cpp" line="185"/>
         <source>Deselect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="185"/>
+        <location filename="../gui/configuration_dialog.cpp" line="186"/>
         <source>Select row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="186"/>
+        <location filename="../gui/configuration_dialog.cpp" line="187"/>
         <source>Select column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="187"/>
+        <location filename="../gui/configuration_dialog.cpp" line="188"/>
         <source>Select pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="188"/>
+        <location filename="../gui/configuration_dialog.cpp" line="189"/>
         <source>Select order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="189"/>
+        <location filename="../gui/configuration_dialog.cpp" line="190"/>
         <source>Go to step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="190"/>
+        <location filename="../gui/configuration_dialog.cpp" line="191"/>
         <source>Toggle track</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="191"/>
+        <location filename="../gui/configuration_dialog.cpp" line="192"/>
         <source>Solo track</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="192"/>
+        <location filename="../gui/configuration_dialog.cpp" line="193"/>
         <source>Interpolate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="193"/>
+        <location filename="../gui/configuration_dialog.cpp" line="194"/>
         <source>Reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="194"/>
+        <location filename="../gui/configuration_dialog.cpp" line="195"/>
         <source>Go to previous order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="195"/>
+        <location filename="../gui/configuration_dialog.cpp" line="196"/>
         <source>Go to next order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="196"/>
+        <location filename="../gui/configuration_dialog.cpp" line="197"/>
         <source>Toggle bookmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="197"/>
+        <location filename="../gui/configuration_dialog.cpp" line="198"/>
         <source>Previous bookmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="198"/>
+        <location filename="../gui/configuration_dialog.cpp" line="199"/>
         <source>Next bookmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="199"/>
+        <location filename="../gui/configuration_dialog.cpp" line="200"/>
         <source>Transpose, decrease note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="200"/>
+        <location filename="../gui/configuration_dialog.cpp" line="201"/>
         <source>Transpose, increase note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="201"/>
+        <location filename="../gui/configuration_dialog.cpp" line="202"/>
         <source>Transpose, decrease octave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="202"/>
+        <location filename="../gui/configuration_dialog.cpp" line="203"/>
         <source>Transpose, increase octave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="203"/>
+        <location filename="../gui/configuration_dialog.cpp" line="204"/>
         <source>Previous instrument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="204"/>
+        <location filename="../gui/configuration_dialog.cpp" line="205"/>
         <source>Next instrument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="205"/>
+        <location filename="../gui/configuration_dialog.cpp" line="206"/>
         <source>Mask instrument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="206"/>
+        <location filename="../gui/configuration_dialog.cpp" line="207"/>
         <source>Mask volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="207"/>
+        <location filename="../gui/configuration_dialog.cpp" line="208"/>
         <source>Edit instrument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="208"/>
+        <location filename="../gui/configuration_dialog.cpp" line="209"/>
         <source>Follow mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="209"/>
+        <location filename="../gui/configuration_dialog.cpp" line="210"/>
         <source>Duplicate order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="210"/>
+        <location filename="../gui/configuration_dialog.cpp" line="211"/>
         <source>Clone patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="211"/>
+        <location filename="../gui/configuration_dialog.cpp" line="212"/>
         <source>Clone order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="212"/>
+        <location filename="../gui/configuration_dialog.cpp" line="213"/>
         <source>Replace instrument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="213"/>
+        <location filename="../gui/configuration_dialog.cpp" line="214"/>
         <source>Expand pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="214"/>
+        <location filename="../gui/configuration_dialog.cpp" line="215"/>
         <source>Shrink pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="215"/>
+        <location filename="../gui/configuration_dialog.cpp" line="216"/>
         <source>Fine decrease values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="216"/>
+        <location filename="../gui/configuration_dialog.cpp" line="217"/>
         <source>Fine increase values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="217"/>
+        <location filename="../gui/configuration_dialog.cpp" line="218"/>
         <source>Coarse decrease values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="218"/>
+        <location filename="../gui/configuration_dialog.cpp" line="219"/>
         <source>Coarse increase valuse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="219"/>
+        <location filename="../gui/configuration_dialog.cpp" line="220"/>
         <source>Expand effect column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="220"/>
+        <location filename="../gui/configuration_dialog.cpp" line="221"/>
         <source>Shrink effect column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="221"/>
+        <location filename="../gui/configuration_dialog.cpp" line="222"/>
         <source>Previous highlighted step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="222"/>
+        <location filename="../gui/configuration_dialog.cpp" line="223"/>
         <source>Next highlighted step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="223"/>
+        <location filename="../gui/configuration_dialog.cpp" line="224"/>
         <source>Increase pattern size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="224"/>
+        <location filename="../gui/configuration_dialog.cpp" line="225"/>
         <source>Decrease pattern size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="225"/>
+        <location filename="../gui/configuration_dialog.cpp" line="226"/>
         <source>Increase edit step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="226"/>
+        <location filename="../gui/configuration_dialog.cpp" line="227"/>
         <source>Decrease edit step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="227"/>
+        <location filename="../gui/configuration_dialog.cpp" line="228"/>
         <source>Display effect list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="228"/>
+        <location filename="../gui/configuration_dialog.cpp" line="229"/>
         <source>Previous song</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="229"/>
+        <location filename="../gui/configuration_dialog.cpp" line="230"/>
         <source>Next song</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="230"/>
+        <location filename="../gui/configuration_dialog.cpp" line="231"/>
         <source>Jam volume up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="231"/>
+        <location filename="../gui/configuration_dialog.cpp" line="232"/>
         <source>Jam volume down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="314"/>
+        <location filename="../gui/configuration_dialog.cpp" line="315"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="510"/>
+        <location filename="../gui/configuration_dialog.cpp" line="511"/>
         <source>Description: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="604"/>
+        <location filename="../gui/configuration_dialog.cpp" line="605"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1367,40 +1367,40 @@
         <translation type="vanished">Description : </translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="746"/>
+        <location filename="../gui/configuration_dialog.cpp" line="747"/>
         <source>Open color scheme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="748"/>
-        <location filename="../gui/configuration_dialog.cpp" line="768"/>
+        <location filename="../gui/configuration_dialog.cpp" line="749"/>
+        <location filename="../gui/configuration_dialog.cpp" line="769"/>
         <source>ini file (*.ini)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="748"/>
-        <location filename="../gui/configuration_dialog.cpp" line="768"/>
+        <location filename="../gui/configuration_dialog.cpp" line="749"/>
+        <location filename="../gui/configuration_dialog.cpp" line="769"/>
         <source>All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="760"/>
-        <location filename="../gui/configuration_dialog.cpp" line="779"/>
+        <location filename="../gui/configuration_dialog.cpp" line="761"/>
+        <location filename="../gui/configuration_dialog.cpp" line="780"/>
         <source>Error</source>
         <translation type="unfinished">Erreur</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="760"/>
+        <location filename="../gui/configuration_dialog.cpp" line="761"/>
         <source>An unknown error occurred while loading the color scheme.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="766"/>
+        <location filename="../gui/configuration_dialog.cpp" line="767"/>
         <source>Save color scheme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="779"/>
+        <location filename="../gui/configuration_dialog.cpp" line="780"/>
         <source>Failed to save the color scheme.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1408,122 +1408,122 @@
 <context>
     <name>EffectDescription</name>
     <message>
-        <location filename="../gui/effect_description.cpp" line="43"/>
+        <location filename="../gui/effect_description.cpp" line="42"/>
         <source>Arpeggio, x: 2nd note (0-F), y: 3rd note (0-F)</source>
         <translation type="unfinished">Arpège, x : 2nde note (0-F), y : 3ème note (0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="44"/>
+        <location filename="../gui/effect_description.cpp" line="43"/>
         <source>Portamento up, xx: depth (00-FF)</source>
         <translation type="unfinished">Portamento haut, xx : profondeur (00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="45"/>
+        <location filename="../gui/effect_description.cpp" line="44"/>
         <source>Portamento down, xx: depth (00-FF)</source>
         <translation type="unfinished">Portamento bas, xx : profondeur (00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="46"/>
+        <location filename="../gui/effect_description.cpp" line="45"/>
         <source>Tone portamento, xx: depth (00-FF)</source>
         <translation type="unfinished">Portamento de tonalité, xx : profondeur (00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="47"/>
+        <location filename="../gui/effect_description.cpp" line="46"/>
         <source>Vibrato, x: period (0-F), y: depth (0-F)</source>
         <translation type="unfinished">Vibrato, x : période (0-F), y : profondeur (0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="48"/>
+        <location filename="../gui/effect_description.cpp" line="47"/>
         <source>Tremolo, x: period (0-F), y: depth (0-F)</source>
         <translation type="unfinished">Trémolo, x : période (0-F), y : profondeur (0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="49"/>
+        <location filename="../gui/effect_description.cpp" line="48"/>
         <source>Pan, xx: 00 = no sound, 01 = right, 02 = left, 03 = center</source>
         <translation type="unfinished">Pan, xx : 00 = pas de son, 01 = droite, 02 = gauche, 03 = centre</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="50"/>
+        <location filename="../gui/effect_description.cpp" line="49"/>
         <source>Volume slide, x: up (0-F), y: down (0-F)</source>
         <translation type="unfinished">Glissé de volume, x : haut (0-F), y : bas (0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="51"/>
+        <location filename="../gui/effect_description.cpp" line="50"/>
         <source>Jump to beginning of order xx</source>
         <translation type="unfinished">Aller au début de la commande xx</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="52"/>
+        <location filename="../gui/effect_description.cpp" line="51"/>
         <source>End of song</source>
         <translation type="unfinished">Fin du morceau</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="53"/>
+        <location filename="../gui/effect_description.cpp" line="52"/>
         <source>Jump to step xx of next order</source>
         <translation type="unfinished">Aller au pas xx de la prochaine commande</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="54"/>
+        <location filename="../gui/effect_description.cpp" line="53"/>
         <source>Change speed (xx: 00-1F), change tempo (xx: 20-FF)</source>
         <translation type="unfinished">Changement de vitesse (xx : 00-1F), changement de tempo (xx : 20-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="55"/>
+        <location filename="../gui/effect_description.cpp" line="54"/>
         <source>Note delay, xx: count (00-FF)</source>
         <translation type="unfinished">Délai de note, xx : compte (00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="56"/>
+        <location filename="../gui/effect_description.cpp" line="55"/>
         <source>Auto envelope, x: shift amount (0-F), y: shape (0-F)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="57"/>
+        <location filename="../gui/effect_description.cpp" line="56"/>
         <source>Hardware envelope period 1, xx: high byte (00-FF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="58"/>
+        <location filename="../gui/effect_description.cpp" line="57"/>
         <source>Hardware envelope period 2, xx: low byte (00-FF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="59"/>
+        <location filename="../gui/effect_description.cpp" line="58"/>
         <source>Retrigger, x: volume slide (0-7: up, 8-F: down), y: tick (1-F)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="60"/>
+        <location filename="../gui/effect_description.cpp" line="59"/>
         <source>Set groove xx</source>
         <translation type="unfinished">Paramétrer le groove xx</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="61"/>
+        <location filename="../gui/effect_description.cpp" line="60"/>
         <source>Detune, xx: pitch (00-FF)</source>
         <translation type="unfinished">Désaccordage, xx : tonalité (00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="62"/>
+        <location filename="../gui/effect_description.cpp" line="61"/>
         <source>Note slide up, x: count (0-F), y: seminote (0-F)</source>
         <translation type="unfinished">Note glissée vers le haut, x : compte (0-F), y : demi-note (0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="63"/>
+        <location filename="../gui/effect_description.cpp" line="62"/>
         <source>Note slide down, x: count (0-F), y: seminote (0-F)</source>
         <translation type="unfinished">Note glissée vers le bas, x : compte (0-F), y : demi-note (0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="64"/>
+        <location filename="../gui/effect_description.cpp" line="63"/>
         <source>Note cut, xx: count (00-FF)</source>
         <translation type="unfinished">Coupure de note, xx : compte (01-FF) {00-?}</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="65"/>
+        <location filename="../gui/effect_description.cpp" line="64"/>
         <source>Transpose delay, x: count (0-7: up, 8-F: down), y: seminote (0-F)</source>
         <translation type="unfinished">Délai de transposition, x : compte (1-7 : haut, 9-F : bas), y : demi-note (0-F) {0-7:?} {8-?} {0-?}</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="79"/>
+        <location filename="../gui/effect_description.cpp" line="78"/>
         <source>Volume delay, x: count (0-F), yy: volume (00-FF)</source>
         <translation type="unfinished">Délai de volume, x : compte (1-F), yy : volume (00-FF) {0-?} {00-?}</translation>
     </message>
@@ -1536,67 +1536,67 @@
         <translation type="obsolete">Délai de transposition, x : compte (1-7 : haut, 9-F : bas), y : demi-note (0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="66"/>
+        <location filename="../gui/effect_description.cpp" line="65"/>
         <source>Tone/Noise mix, xx: 00 = no sound, 01 = tone, 02 = noise, 03 = tone &amp; noise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="67"/>
+        <location filename="../gui/effect_description.cpp" line="66"/>
         <source>Master volume, xx: volume (00-3F)</source>
         <translation type="unfinished">Volume maître, xx : volume (00-3F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="68"/>
+        <location filename="../gui/effect_description.cpp" line="67"/>
         <source>Noise pitch, xx: pitch (00-1F)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="69"/>
+        <location filename="../gui/effect_description.cpp" line="68"/>
         <source>Register address bank 0, xx: address (00-6B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="70"/>
+        <location filename="../gui/effect_description.cpp" line="69"/>
         <source>Register address bank 1, xx: address (00-6B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="71"/>
+        <location filename="../gui/effect_description.cpp" line="70"/>
         <source>Register value set, xx: value (00-FF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="72"/>
+        <location filename="../gui/effect_description.cpp" line="71"/>
         <source>AR control, x: operator (1-4), yy: attack rate (00-1F)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="73"/>
+        <location filename="../gui/effect_description.cpp" line="72"/>
         <source>Brightness, xx: relative value (01-FF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="74"/>
+        <location filename="../gui/effect_description.cpp" line="73"/>
         <source>DR control, x: operator (1-4), yy: decay rate (00-1F)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="75"/>
+        <location filename="../gui/effect_description.cpp" line="74"/>
         <source>Envelope reset, xx: count (00-FF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="76"/>
+        <location filename="../gui/effect_description.cpp" line="75"/>
         <source>FB control, xx: feedback value (00-07)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="77"/>
+        <location filename="../gui/effect_description.cpp" line="76"/>
         <source>Fine detune, xx: pitch (00-FF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="78"/>
+        <location filename="../gui/effect_description.cpp" line="77"/>
         <source>ML control, x: operator (1-4), y: multiple (0-F)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1605,17 +1605,17 @@
         <translation type="obsolete">Délai de volume, x : compte (1-F), yy : volume (00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="80"/>
+        <location filename="../gui/effect_description.cpp" line="79"/>
         <source>RR control, x: operator (1-4), y: release rate (0-F)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="81"/>
+        <location filename="../gui/effect_description.cpp" line="80"/>
         <source>TL control, x: operator (1-4), yy: total level (00-7F)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="82"/>
+        <location filename="../gui/effect_description.cpp" line="81"/>
         <source>Invalid effect</source>
         <translation type="unfinished">Effet invalide</translation>
     </message>
@@ -1828,42 +1828,42 @@
 <context>
     <name>FileIOErrorMessageBox</name>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="54"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="55"/>
         <source>Path does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="57"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="58"/>
         <source>Unsupported file format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="60"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="61"/>
         <source>Could not load the %1 properly. Please make sure that you have the latest version of BambooTracker.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="64"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="65"/>
         <source>Could not load the %1. It may be corrupted. Stopped at %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="73"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="74"/>
         <source>Failed to load %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="80"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="81"/>
         <source>Failed to export to %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="83"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="84"/>
         <source>Failed to save the %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="92"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="93"/>
         <source>Error</source>
         <translation type="unfinished">Erreur</translation>
     </message>
@@ -1876,32 +1876,32 @@
 <context>
     <name>FileType</name>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="32"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="33"/>
         <source>module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="33"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="34"/>
         <source>s98</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="34"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="35"/>
         <source>vgm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="35"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="36"/>
         <source>wav</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="36"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="37"/>
         <source>bank</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="37"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="38"/>
         <source>instrument</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2676,16 +2676,16 @@
         <translation type="vanished">Style</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2066"/>
-        <location filename="../gui/mainwindow.cpp" line="2521"/>
-        <location filename="../gui/mainwindow.cpp" line="2523"/>
-        <location filename="../gui/mainwindow.cpp" line="2549"/>
+        <location filename="../gui/mainwindow.cpp" line="2061"/>
+        <location filename="../gui/mainwindow.cpp" line="2516"/>
+        <location filename="../gui/mainwindow.cpp" line="2518"/>
+        <location filename="../gui/mainwindow.cpp" line="2544"/>
         <source>Untitled</source>
         <translation>Sans titre</translation>
     </message>
     <message>
         <location filename="../gui/mainwindow.ui" line="244"/>
-        <location filename="../gui/mainwindow.cpp" line="3693"/>
+        <location filename="../gui/mainwindow.cpp" line="3688"/>
         <source>Groove</source>
         <translation>Groove</translation>
     </message>
@@ -3526,14 +3526,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="267"/>
+        <location filename="../gui/mainwindow.cpp" line="262"/>
         <source>Octave</source>
         <translation>Octave</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="280"/>
-        <location filename="../gui/mainwindow.cpp" line="541"/>
-        <location filename="../gui/mainwindow.cpp" line="2331"/>
+        <location filename="../gui/mainwindow.cpp" line="275"/>
+        <location filename="../gui/mainwindow.cpp" line="536"/>
+        <location filename="../gui/mainwindow.cpp" line="2326"/>
         <source>Octave: %1</source>
         <translation>Octave : %1</translation>
     </message>
@@ -3542,25 +3542,25 @@
         <translation type="vanished">Sauvegarder les modifications dans %1 ?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="543"/>
+        <location filename="../gui/mainwindow.cpp" line="538"/>
         <source>Welcome to BambooTracker v%1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2509"/>
-        <location filename="../gui/mainwindow.hpp" line="234"/>
-        <location filename="../gui/mainwindow.hpp" line="250"/>
+        <location filename="../gui/mainwindow.cpp" line="2504"/>
+        <location filename="../gui/mainwindow.hpp" line="243"/>
+        <location filename="../gui/mainwindow.hpp" line="259"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1353"/>
-        <location filename="../gui/mainwindow.cpp" line="1374"/>
+        <location filename="../gui/mainwindow.cpp" line="1348"/>
+        <location filename="../gui/mainwindow.cpp" line="1369"/>
         <source>Instrument %1</source>
         <translation>Instrument %1</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1705"/>
+        <location filename="../gui/mainwindow.cpp" line="1700"/>
         <source>Open instrument</source>
         <translation>Ouvrir l&apos;instrument</translation>
     </message>
@@ -3569,50 +3569,50 @@
         <translation type="vanished">Le chargement de l&apos;instrument a échoué.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1769"/>
+        <location filename="../gui/mainwindow.cpp" line="1764"/>
         <source>Save instrument</source>
         <translation>Sauvegarder l&apos;instrument</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1815"/>
+        <location filename="../gui/mainwindow.cpp" line="1810"/>
         <source>Open bank</source>
         <translation>Ouvrir la banque</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1879"/>
+        <location filename="../gui/mainwindow.cpp" line="1874"/>
         <source>Select instruments to load:</source>
         <translation>Sélectionnez les instruments à charger :</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2538"/>
-        <location filename="../gui/mainwindow.cpp" line="2588"/>
+        <location filename="../gui/mainwindow.cpp" line="2533"/>
+        <location filename="../gui/mainwindow.cpp" line="2583"/>
         <source>No instrument</source>
         <translation>Pas d&apos;instrument</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2228"/>
+        <location filename="../gui/mainwindow.cpp" line="2223"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="174"/>
+        <location filename="../gui/mainwindow.cpp" line="169"/>
         <source>English</source>
         <comment>Default notation system</comment>
         <extracomment>Set the name of suitable notation system (English or German)</extracomment>
         <translation type="unfinished">Anglais</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="283"/>
+        <location filename="../gui/mainwindow.cpp" line="278"/>
         <source>Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="300"/>
+        <location filename="../gui/mainwindow.cpp" line="295"/>
         <source>Step highlight 1st</source>
         <translation>1er intervalle en surbrillance</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="316"/>
+        <location filename="../gui/mainwindow.cpp" line="311"/>
         <source>2nd</source>
         <translation>2nd</translation>
     </message>
@@ -3653,127 +3653,127 @@
         <translation type="vanished">Banque WOPN (*.wopn)</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1968"/>
+        <location filename="../gui/mainwindow.cpp" line="1963"/>
         <source>Select instruments to save:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1979"/>
+        <location filename="../gui/mainwindow.cpp" line="1974"/>
         <source>Save bank</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2095"/>
+        <location filename="../gui/mainwindow.cpp" line="2090"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2100"/>
+        <location filename="../gui/mainwindow.cpp" line="2095"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2105"/>
+        <location filename="../gui/mainwindow.cpp" line="2100"/>
         <source>PC-9821 with PC-9801-86</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2110"/>
+        <location filename="../gui/mainwindow.cpp" line="2105"/>
         <source>PC-9821 with Speak Board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2115"/>
+        <location filename="../gui/mainwindow.cpp" line="2110"/>
         <source>PC-88VA2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2120"/>
+        <location filename="../gui/mainwindow.cpp" line="2115"/>
         <source>NEC PC-8801mkIISR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2229"/>
+        <location filename="../gui/mainwindow.cpp" line="2224"/>
         <source>FM3ch expanded</source>
         <translation>FM3canaux étendu</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2258"/>
+        <location filename="../gui/mainwindow.cpp" line="2253"/>
         <source>Insufficient memory size to load ADPCM samples. Please delete the unused samples.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2409"/>
+        <location filename="../gui/mainwindow.cpp" line="2404"/>
         <source>The module has been changed. Do you want to save it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.hpp" line="251"/>
+        <location filename="../gui/mainwindow.hpp" line="260"/>
         <source>Could not initialize MIDI input.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2590"/>
+        <location filename="../gui/mainwindow.cpp" line="2585"/>
         <source>Instrument: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3196"/>
-        <location filename="../gui/mainwindow.cpp" line="3262"/>
+        <location filename="../gui/mainwindow.cpp" line="3191"/>
+        <location filename="../gui/mainwindow.cpp" line="3257"/>
         <source>BambooTracker module (*.btm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3196"/>
-        <location filename="../gui/mainwindow.cpp" line="3262"/>
-        <location filename="../gui/mainwindow.cpp" line="3383"/>
-        <location filename="../gui/mainwindow.cpp" line="3518"/>
-        <location filename="../gui/mainwindow.cpp" line="3586"/>
+        <location filename="../gui/mainwindow.cpp" line="3191"/>
+        <location filename="../gui/mainwindow.cpp" line="3257"/>
+        <location filename="../gui/mainwindow.cpp" line="3378"/>
+        <location filename="../gui/mainwindow.cpp" line="3513"/>
+        <location filename="../gui/mainwindow.cpp" line="3581"/>
         <source>All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3383"/>
+        <location filename="../gui/mainwindow.cpp" line="3378"/>
         <source>WAV signed 16-bit PCM (*.wav)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3421"/>
+        <location filename="../gui/mainwindow.cpp" line="3416"/>
         <source>Export %1 to WAV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3518"/>
+        <location filename="../gui/mainwindow.cpp" line="3513"/>
         <source>VGM file (*.vgm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3586"/>
+        <location filename="../gui/mainwindow.cpp" line="3581"/>
         <source>S98 file (*.s98)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3753"/>
+        <location filename="../gui/mainwindow.cpp" line="3748"/>
         <source>Do you want to remove all duplicate instruments?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3856"/>
+        <location filename="../gui/mainwindow.cpp" line="3851"/>
         <source>Do you want to remove all unused ADPCM samples?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3899"/>
+        <location filename="../gui/mainwindow.cpp" line="3894"/>
         <source>Do you want to transpose a song?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3920"/>
+        <location filename="../gui/mainwindow.cpp" line="3915"/>
         <source>Do you want to swap tracks?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3974"/>
+        <location filename="../gui/mainwindow.cpp" line="3969"/>
         <source>Approximate song length: %1m%2s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3818,188 +3818,188 @@
         <translation type="vanished">Instrument : </translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2881"/>
+        <location filename="../gui/mainwindow.cpp" line="2876"/>
         <source>Do you want to change song properties?</source>
         <translation>Voulez-vous modifier les propriétés du morceau ?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2957"/>
+        <location filename="../gui/mainwindow.cpp" line="2952"/>
         <source>Change to jam mode</source>
         <translation>Passage en mode jeu</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2957"/>
+        <location filename="../gui/mainwindow.cpp" line="2952"/>
         <source>Change to edit mode</source>
         <translation>Passage en mode édition</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3024"/>
+        <location filename="../gui/mainwindow.cpp" line="3019"/>
         <source>About</source>
         <translation>À propos</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2509"/>
+        <location filename="../gui/mainwindow.cpp" line="2504"/>
         <source>Failed to backup module.</source>
         <translation>La sauvegarde du module a échoué.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="683"/>
+        <location filename="../gui/mainwindow.cpp" line="678"/>
         <source>Welcome to BambooTracker!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="687"/>
+        <location filename="../gui/mainwindow.cpp" line="682"/>
         <source>Don&apos;t know where to start?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="688"/>
+        <location filename="../gui/mainwindow.cpp" line="683"/>
         <source>Check the demo modules and instruments included with your download of BambooTracker.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="690"/>
+        <location filename="../gui/mainwindow.cpp" line="685"/>
         <source>Need a list of effects and shortcuts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="691"/>
+        <location filename="../gui/mainwindow.cpp" line="686"/>
         <source>Check the Help menu at the top of the window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="692"/>
+        <location filename="../gui/mainwindow.cpp" line="687"/>
         <source>Still lost?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="693"/>
+        <location filename="../gui/mainwindow.cpp" line="688"/>
         <source>The README.md has a link to our Discord server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="694"/>
+        <location filename="../gui/mainwindow.cpp" line="689"/>
         <source>Think you&apos;ve found a bug? Missing a feature?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="695"/>
+        <location filename="../gui/mainwindow.cpp" line="690"/>
         <source>BambooTracker is still in development, bugs and missing features are to be expected. So we need your help!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="699"/>
+        <location filename="../gui/mainwindow.cpp" line="694"/>
         <source>Please report any bugs you find and requests and features you&apos;d like to see on our Discord server or our bug tracker (%1).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="703"/>
+        <location filename="../gui/mainwindow.cpp" line="698"/>
         <source>If you&apos;re a developer yourself or would like to start being one, consider contributing to the project yourself. Any help would be appreciated!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="707"/>
+        <location filename="../gui/mainwindow.cpp" line="702"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1724"/>
-        <location filename="../gui/mainwindow.cpp" line="1936"/>
+        <location filename="../gui/mainwindow.cpp" line="1719"/>
+        <location filename="../gui/mainwindow.cpp" line="1931"/>
         <source>The number of instruments has reached the upper limit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2979"/>
+        <location filename="../gui/mainwindow.cpp" line="2974"/>
         <source>YM2608 Music Tracker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2981"/>
+        <location filename="../gui/mainwindow.cpp" line="2976"/>
         <source>Web:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2984"/>
+        <location filename="../gui/mainwindow.cpp" line="2979"/>
         <source>This software is licensed under the GNU General Public License v2.0 or later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2985"/>
+        <location filename="../gui/mainwindow.cpp" line="2980"/>
         <source>Source is available at:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2988"/>
+        <location filename="../gui/mainwindow.cpp" line="2983"/>
         <source>Libraries:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2989"/>
+        <location filename="../gui/mainwindow.cpp" line="2984"/>
         <source>Also see changelog which lists contributors.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2990"/>
+        <location filename="../gui/mainwindow.cpp" line="2985"/>
         <source>Thank you to everyone who reports bugs, makes suggestions, and contributes to this project!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2994"/>
+        <location filename="../gui/mainwindow.cpp" line="2989"/>
         <source>C86CTL by (C) honet (BSD 3-Clause)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2996"/>
+        <location filename="../gui/mainwindow.cpp" line="2991"/>
         <source>emu2149 by (C) Mitsutaka Okazaki (MIT License)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2997"/>
+        <location filename="../gui/mainwindow.cpp" line="2992"/>
         <source>fmopn by (C) Tatsuyuki Satoh, Jarek Burczynski, ValleyBell (GPL v2+)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2998"/>
+        <location filename="../gui/mainwindow.cpp" line="2993"/>
         <source>libOPNMIDI by (C) Vitaly Novichkov (MIT License part)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2999"/>
+        <location filename="../gui/mainwindow.cpp" line="2994"/>
         <source>Nuked OPN-MOD by (C) Alexey Khokholov (Nuke.YKT), Jean Pierre Cimalando (LGPL v2.1+)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3000"/>
+        <location filename="../gui/mainwindow.cpp" line="2995"/>
         <source>Qt (GPL v2+ or LGPL v3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3001"/>
+        <location filename="../gui/mainwindow.cpp" line="2996"/>
         <source>RtAudio by (C) Gary P. Scavone (RtAudio License)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3002"/>
+        <location filename="../gui/mainwindow.cpp" line="2997"/>
         <source>RtMidi by (C) Gary P. Scavone (RtMidi License)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3004"/>
+        <location filename="../gui/mainwindow.cpp" line="2999"/>
         <source>SCCI by (C) gasshi (SCCI License)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3006"/>
+        <location filename="../gui/mainwindow.cpp" line="3001"/>
         <source>Silk icons by (C) Mark James (CC BY 2.5 or 3.0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3007"/>
+        <location filename="../gui/mainwindow.cpp" line="3002"/>
         <source>ymdeltat by (C) Tatsuyuki Satoh, Jarek Burczynski, ValleyBell (GPL v2+)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3194"/>
+        <location filename="../gui/mainwindow.cpp" line="3189"/>
         <source>Save module</source>
         <translation>Sauvegarder le module</translation>
     </message>
@@ -4008,17 +4008,17 @@
         <translation type="vanished">Fichier de module BambooTracker (*.btm)</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3261"/>
+        <location filename="../gui/mainwindow.cpp" line="3256"/>
         <source>Open module</source>
         <translation>Ouvrir le module</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3331"/>
+        <location filename="../gui/mainwindow.cpp" line="3326"/>
         <source>Do you want to remove all unused instruments?</source>
         <translation>Voulez-vous supprimer tous les instruments inutilisés ?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3352"/>
+        <location filename="../gui/mainwindow.cpp" line="3347"/>
         <source>Do you want to remove all unused patterns?</source>
         <translation>Voulez-vous supprimer tous les motifs inutilisés ?</translation>
     </message>
@@ -4027,15 +4027,15 @@
         <translation type="vanished">Exporter en wav</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3381"/>
-        <location filename="../gui/mainwindow.cpp" line="3415"/>
+        <location filename="../gui/mainwindow.cpp" line="3376"/>
+        <location filename="../gui/mainwindow.cpp" line="3410"/>
         <source>Export to WAV</source>
         <translation>Exporter en WAV</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3394"/>
-        <location filename="../gui/mainwindow.cpp" line="3527"/>
-        <location filename="../gui/mainwindow.cpp" line="3595"/>
+        <location filename="../gui/mainwindow.cpp" line="3389"/>
+        <location filename="../gui/mainwindow.cpp" line="3522"/>
+        <location filename="../gui/mainwindow.cpp" line="3590"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -4048,8 +4048,8 @@
         <translation type="vanished">Exporter en vgm</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3516"/>
-        <location filename="../gui/mainwindow.cpp" line="3527"/>
+        <location filename="../gui/mainwindow.cpp" line="3511"/>
+        <location filename="../gui/mainwindow.cpp" line="3522"/>
         <source>Export to VGM</source>
         <translation>Exporter en VGM</translation>
     </message>
@@ -4062,8 +4062,8 @@
         <translation type="vanished">Exporter en s98</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3584"/>
-        <location filename="../gui/mainwindow.cpp" line="3595"/>
+        <location filename="../gui/mainwindow.cpp" line="3579"/>
+        <location filename="../gui/mainwindow.cpp" line="3590"/>
         <source>Export to S98</source>
         <translation>Exporter en S98</translation>
     </message>
@@ -4072,25 +4072,25 @@
         <translation type="vanished">L&apos;exportation en fichier s98 a échoué.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2257"/>
-        <location filename="../gui/mainwindow.cpp" line="2408"/>
-        <location filename="../gui/mainwindow.hpp" line="226"/>
-        <location filename="../gui/mainwindow.hpp" line="242"/>
+        <location filename="../gui/mainwindow.cpp" line="2252"/>
+        <location filename="../gui/mainwindow.cpp" line="2403"/>
+        <location filename="../gui/mainwindow.hpp" line="235"/>
+        <location filename="../gui/mainwindow.hpp" line="251"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.hpp" line="227"/>
+        <location filename="../gui/mainwindow.hpp" line="236"/>
         <source>%1 If you execute this command, the command history is reset.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.hpp" line="235"/>
+        <location filename="../gui/mainwindow.hpp" line="244"/>
         <source>Could not open the audio stream. Please change the sound settings in Configuration.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.hpp" line="243"/>
+        <location filename="../gui/mainwindow.hpp" line="252"/>
         <source>Could not set the sample rate of the audio stream to %1Hz. Currently the stream runs on %2Hz instead.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4239,12 +4239,12 @@
 <context>
     <name>ModuleSaveCheckDialog</name>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="108"/>
+        <location filename="../gui/mainwindow.cpp" line="105"/>
         <source>Save changes to %1?</source>
         <translation type="unfinished">Sauvegarder les modifications dans %1 ?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="108"/>
+        <location filename="../gui/mainwindow.cpp" line="105"/>
         <source>Untitled</source>
         <translation type="unfinished">Sans titre</translation>
     </message>
@@ -4252,12 +4252,12 @@
 <context>
     <name>NotationSystem</name>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="71"/>
+        <location filename="../gui/configuration_dialog.cpp" line="72"/>
         <source>English</source>
         <translation type="unfinished">Anglais</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="72"/>
+        <location filename="../gui/configuration_dialog.cpp" line="73"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4332,17 +4332,17 @@
 <context>
     <name>Panning</name>
     <message>
-        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="40"/>
+        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="41"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="41"/>
+        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="42"/>
         <source>Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="42"/>
+        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="43"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4804,12 +4804,12 @@
 <context>
     <name>SongType</name>
     <message>
-        <location filename="../gui/module_properties_dialog.cpp" line="37"/>
+        <location filename="../gui/module_properties_dialog.cpp" line="38"/>
         <source>Standard</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../gui/module_properties_dialog.cpp" line="38"/>
+        <location filename="../gui/module_properties_dialog.cpp" line="39"/>
         <source>FM3ch expanded</source>
         <translation type="unfinished">FM3canaux étendu</translation>
     </message>

--- a/BambooTracker/lang/bamboo_tracker_ja.ts
+++ b/BambooTracker/lang/bamboo_tracker_ja.ts
@@ -238,7 +238,7 @@
     <name>ConfigurationDialog</name>
     <message>
         <location filename="../gui/configuration_dialog.ui" line="14"/>
-        <location filename="../gui/configuration_dialog.cpp" line="499"/>
+        <location filename="../gui/configuration_dialog.cpp" line="500"/>
         <source>Configuration</source>
         <translation>設定</translation>
     </message>
@@ -715,22 +715,22 @@
         <translation>高音</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="163"/>
+        <location filename="../gui/configuration_dialog.cpp" line="164"/>
         <source>Key off</source>
         <translation>キーオフ</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="164"/>
+        <location filename="../gui/configuration_dialog.cpp" line="165"/>
         <source>Octave up</source>
         <translation>オクターブアップ</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="165"/>
+        <location filename="../gui/configuration_dialog.cpp" line="166"/>
         <source>Octave down</source>
         <translation>オクターブダウン</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="166"/>
+        <location filename="../gui/configuration_dialog.cpp" line="167"/>
         <source>Echo buffer</source>
         <translation>エコーバッファ</translation>
     </message>
@@ -879,491 +879,491 @@
         <translation>リセット</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="584"/>
+        <location filename="../gui/configuration_dialog.cpp" line="585"/>
         <source>Virtual port</source>
         <translation>仮想ポート</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="360"/>
+        <location filename="../gui/configuration_dialog.cpp" line="361"/>
         <source>Master</source>
         <translation>マスター</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="499"/>
+        <location filename="../gui/configuration_dialog.cpp" line="500"/>
         <source>The change of emulator will be effective after restarting the program.</source>
         <translation>エミュレータのの変更は次回起動以降に反映されます。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="102"/>
+        <location filename="../gui/configuration_dialog.cpp" line="103"/>
         <source>Warp the cursor around the edges of the pattern editor.</source>
         <translation>パターンの両端をワープします。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="104"/>
+        <location filename="../gui/configuration_dialog.cpp" line="105"/>
         <source>Move to previous or next order when reaching top or bottom in the pattern editor.</source>
         <translation>パターンの上下の端から前後のパターンへ移動します。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="106"/>
+        <location filename="../gui/configuration_dialog.cpp" line="107"/>
         <source>Display row numbers and the playback position on the status bar in hexadecimal.</source>
         <translation>オーダー番号とステップ番号を16進数で表示します。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="108"/>
+        <location filename="../gui/configuration_dialog.cpp" line="109"/>
         <source>Preview previous and next orders in the pattern editor.</source>
         <translation>パターンエディターで前後のオーダーをプレビューします。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="110"/>
+        <location filename="../gui/configuration_dialog.cpp" line="111"/>
         <source>Create a backup copy of the existing file when saving a module.</source>
         <translation>モジュール保存時に既存のデータをコピーしてバックアップを作成します。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="112"/>
+        <location filename="../gui/configuration_dialog.cpp" line="113"/>
         <source>Don&apos;t select the whole track when double-clicking in the pattern editor.</source>
         <translation>パターンエディターでのダブルクリック時にトラック全体を選択しないようにします。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="114"/>
+        <location filename="../gui/configuration_dialog.cpp" line="115"/>
         <source>Reverse the order of FM volume so that 00 is the quietest in the pattern editor.</source>
         <oldsource>Reverse the order of FM volume so that 00 is the quietest in the pattern editor</oldsource>
         <translation>パターンエディターでFMの音量を00が最小になるよう順序を変更します。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="116"/>
+        <location filename="../gui/configuration_dialog.cpp" line="117"/>
         <source>Move the cursor to right after entering effects in the pattern editor.</source>
         <translation>パターンエディターでエフェクト入力後にカーソルを右の列へ移動します。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="118"/>
+        <location filename="../gui/configuration_dialog.cpp" line="119"/>
         <source>Reconstruct the current channel&apos;s state from previous orders upon playing.</source>
         <translation>再生時に以前のオーダーから現在のチャンネルの状態を再構築します。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="120"/>
+        <location filename="../gui/configuration_dialog.cpp" line="121"/>
         <source>Translate to your language from the next launch. See readme to check supported languages.</source>
         <translation>テキストが次回の起動時からあなたの言語に翻訳されます。サポートされている言語についてはreadmeを参照してください。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="122"/>
+        <location filename="../gui/configuration_dialog.cpp" line="123"/>
         <source>Display FM detune values as signed numbers in the FM envelope editor.</source>
         <translation>FMエンベロープエディタでFMのデチューン値を符号付きの値として表示します。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="124"/>
+        <location filename="../gui/configuration_dialog.cpp" line="125"/>
         <source>Fill 00 to effect value column upon entering effect id.</source>
         <translation>エフェクトIDを入力時にエフェクト値を自動で00に設定します。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="126"/>
+        <location filename="../gui/configuration_dialog.cpp" line="127"/>
         <source>Move the cursor position by cell with horizontal scroll bar in the order list and the pattern editor.</source>
         <translation>オーダーリストとパターンエディターにおいて横スクロールバーでカーソルをセル単位で移動させます。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="128"/>
+        <location filename="../gui/configuration_dialog.cpp" line="129"/>
         <source>Overwrite unused and unedited instrument properties on creating new properties. When disabled, override unused properties regardless of editing.</source>
         <translation>新しいインストゥルメントプロパティを作成する際に未使用かつ未編集の既存のプロパティを上書きします。編集したかどうかに関わらず上書きする場合はチェックを外してください。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="131"/>
+        <location filename="../gui/configuration_dialog.cpp" line="132"/>
         <source>Send only ADPCM samples used by instruments to the ADPCM memory. Recommend to turn off if you change ADPCM samples frequently due to take the high rewriting cost.</source>
         <translation>インストゥルメントで使用されているADPCMサンプルのみをADPCMメモリへ書き込みます。メモリの書きかえには高コストであるため、頻繁にサンプルを変更する場合には無効にすることをお勧めします。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="134"/>
+        <location filename="../gui/configuration_dialog.cpp" line="135"/>
         <source>Correspond the instrument number in patterns when the instrument changes its number.</source>
         <translation>インストゥルメントの番号が変更されたとき、パターン中の対応するインストゥルメント番号を同期させます。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="136"/>
+        <location filename="../gui/configuration_dialog.cpp" line="137"/>
         <source>Set maximum volume during jam mode. When unchecked, the volume is changed by the volume spinbox.</source>
         <translation>ジャムモード中のインストゥルメントの音量を最大に固定します。無効時にはツールバーの音量設定によって音量が変更されます。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="138"/>
+        <location filename="../gui/configuration_dialog.cpp" line="139"/>
         <source>Mute hidden tracks when visibility of tracks is changed.</source>
         <translation>トラックの可視性が変更されたとき、非表示のトラックをミュートします。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="140"/>
+        <location filename="../gui/configuration_dialog.cpp" line="141"/>
         <source>Restore the previous track visibility on startup.</source>
         <translation>起動時に前回のプログラム終了時のトラックの可視状態を復元します。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="167"/>
+        <location filename="../gui/configuration_dialog.cpp" line="168"/>
         <source>Play and stop</source>
         <translation>再生/停止</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="168"/>
+        <location filename="../gui/configuration_dialog.cpp" line="169"/>
         <source>Play</source>
         <translation>再生</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="169"/>
+        <location filename="../gui/configuration_dialog.cpp" line="170"/>
         <source>Play from start</source>
         <translation>最初から再生</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="170"/>
+        <location filename="../gui/configuration_dialog.cpp" line="171"/>
         <source>Play pattern</source>
         <translation>パターンを再生</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="171"/>
+        <location filename="../gui/configuration_dialog.cpp" line="172"/>
         <source>Play from cursor</source>
         <translation>カーソル位置から再生</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="172"/>
+        <location filename="../gui/configuration_dialog.cpp" line="173"/>
         <source>Play from marker</source>
         <translation>マーカー位置から再生</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="173"/>
+        <location filename="../gui/configuration_dialog.cpp" line="174"/>
         <source>Play step</source>
         <translation>ステップ再生</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="174"/>
+        <location filename="../gui/configuration_dialog.cpp" line="175"/>
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="175"/>
+        <location filename="../gui/configuration_dialog.cpp" line="176"/>
         <source>Focus on pattern editor</source>
         <translation>パターンエディターへ移動</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="176"/>
+        <location filename="../gui/configuration_dialog.cpp" line="177"/>
         <source>Focus on order list</source>
         <translation>オーダーリストへ移動</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="177"/>
+        <location filename="../gui/configuration_dialog.cpp" line="178"/>
         <source>Focus on instrument list</source>
         <translation>インストゥルメントリストへ移動</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="178"/>
+        <location filename="../gui/configuration_dialog.cpp" line="179"/>
         <source>Toggle edit/jam mode</source>
         <translation>Edit/Jamモード切替え</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="179"/>
+        <location filename="../gui/configuration_dialog.cpp" line="180"/>
         <source>Set marker</source>
         <translation>マーカーを設定</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="180"/>
+        <location filename="../gui/configuration_dialog.cpp" line="181"/>
         <source>Paste and mix</source>
         <translation>ミックス貼り付け</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="181"/>
+        <location filename="../gui/configuration_dialog.cpp" line="182"/>
         <source>Paste and overwrite</source>
         <translation>上書き貼り付け</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="182"/>
+        <location filename="../gui/configuration_dialog.cpp" line="183"/>
         <source>Paste and insert</source>
         <translation>挿入貼り付け</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="183"/>
+        <location filename="../gui/configuration_dialog.cpp" line="184"/>
         <source>Select all</source>
         <translation>全選択</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="184"/>
+        <location filename="../gui/configuration_dialog.cpp" line="185"/>
         <source>Deselect</source>
         <translation>選択解除</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="185"/>
+        <location filename="../gui/configuration_dialog.cpp" line="186"/>
         <source>Select row</source>
         <translation>行を選択</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="186"/>
+        <location filename="../gui/configuration_dialog.cpp" line="187"/>
         <source>Select column</source>
         <translation>列を選択</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="187"/>
+        <location filename="../gui/configuration_dialog.cpp" line="188"/>
         <source>Select pattern</source>
         <translation>パターンを選択</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="188"/>
+        <location filename="../gui/configuration_dialog.cpp" line="189"/>
         <source>Select order</source>
         <translation>オーダーを選択</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="189"/>
+        <location filename="../gui/configuration_dialog.cpp" line="190"/>
         <source>Go to step</source>
         <translation>ステップ移動</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="190"/>
+        <location filename="../gui/configuration_dialog.cpp" line="191"/>
         <source>Toggle track</source>
         <translation>トラックをミュート</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="191"/>
+        <location filename="../gui/configuration_dialog.cpp" line="192"/>
         <source>Solo track</source>
         <translation>トラックをソロ状態に変更</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="192"/>
+        <location filename="../gui/configuration_dialog.cpp" line="193"/>
         <source>Interpolate</source>
         <translation>補間</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="193"/>
+        <location filename="../gui/configuration_dialog.cpp" line="194"/>
         <source>Reverse</source>
         <translation>反転</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="194"/>
+        <location filename="../gui/configuration_dialog.cpp" line="195"/>
         <source>Go to previous order</source>
         <translation>前のオーダーへ移動</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="195"/>
+        <location filename="../gui/configuration_dialog.cpp" line="196"/>
         <source>Go to next order</source>
         <translation>次のオーダーへ移動</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="196"/>
+        <location filename="../gui/configuration_dialog.cpp" line="197"/>
         <source>Toggle bookmark</source>
         <translation>ブックマーク設定</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="197"/>
+        <location filename="../gui/configuration_dialog.cpp" line="198"/>
         <source>Previous bookmark</source>
         <translation>前のブックマークへ移動</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="198"/>
+        <location filename="../gui/configuration_dialog.cpp" line="199"/>
         <source>Next bookmark</source>
         <translation>次のブックマークへ移動</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="199"/>
+        <location filename="../gui/configuration_dialog.cpp" line="200"/>
         <source>Transpose, decrease note</source>
         <translation>トランスポーズ (半音下げる)</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="200"/>
+        <location filename="../gui/configuration_dialog.cpp" line="201"/>
         <source>Transpose, increase note</source>
         <translation>トランスポーズ (半音上げる)</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="201"/>
+        <location filename="../gui/configuration_dialog.cpp" line="202"/>
         <source>Transpose, decrease octave</source>
         <translation>トランスポーズ (1オクターブ下げる)</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="202"/>
+        <location filename="../gui/configuration_dialog.cpp" line="203"/>
         <source>Transpose, increase octave</source>
         <translation>トランスポーズ (1オクターブ上げる)</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="203"/>
+        <location filename="../gui/configuration_dialog.cpp" line="204"/>
         <source>Previous instrument</source>
         <translation>前のインストゥルメントを選択</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="204"/>
+        <location filename="../gui/configuration_dialog.cpp" line="205"/>
         <source>Next instrument</source>
         <translation>次のインストゥルメントを選択</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="205"/>
+        <location filename="../gui/configuration_dialog.cpp" line="206"/>
         <source>Mask instrument</source>
         <translation>インストゥルメント入力をマスク</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="206"/>
+        <location filename="../gui/configuration_dialog.cpp" line="207"/>
         <source>Mask volume</source>
         <translation>音量入力をマスク</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="207"/>
+        <location filename="../gui/configuration_dialog.cpp" line="208"/>
         <source>Edit instrument</source>
         <translation>インストゥルメントを編集</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="208"/>
+        <location filename="../gui/configuration_dialog.cpp" line="209"/>
         <source>Follow mode</source>
         <translation>フォローモード</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="209"/>
+        <location filename="../gui/configuration_dialog.cpp" line="210"/>
         <source>Duplicate order</source>
         <translation>オーダーを複製</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="210"/>
+        <location filename="../gui/configuration_dialog.cpp" line="211"/>
         <source>Clone patterns</source>
         <translation>パターンをクローン</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="211"/>
+        <location filename="../gui/configuration_dialog.cpp" line="212"/>
         <source>Clone order</source>
         <translation>オーダーをクローン</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="212"/>
+        <location filename="../gui/configuration_dialog.cpp" line="213"/>
         <source>Replace instrument</source>
         <translation>インストゥルメント置換</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="213"/>
+        <location filename="../gui/configuration_dialog.cpp" line="214"/>
         <source>Expand pattern</source>
         <translation>パターン拡大</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="214"/>
+        <location filename="../gui/configuration_dialog.cpp" line="215"/>
         <source>Shrink pattern</source>
         <translation>パターン縮小</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="215"/>
+        <location filename="../gui/configuration_dialog.cpp" line="216"/>
         <source>Fine decrease values</source>
         <translation>値を1だけ減少</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="216"/>
+        <location filename="../gui/configuration_dialog.cpp" line="217"/>
         <source>Fine increase values</source>
         <translation>値を1だけ増加</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="217"/>
+        <location filename="../gui/configuration_dialog.cpp" line="218"/>
         <source>Coarse decrease values</source>
         <translation>値を16だけ減少</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="218"/>
+        <location filename="../gui/configuration_dialog.cpp" line="219"/>
         <source>Coarse increase valuse</source>
         <translation>値を16だけ増加</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="219"/>
+        <location filename="../gui/configuration_dialog.cpp" line="220"/>
         <source>Expand effect column</source>
         <translation>エフェクト列の拡張</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="220"/>
+        <location filename="../gui/configuration_dialog.cpp" line="221"/>
         <source>Shrink effect column</source>
         <translation>エフェクト列の縮小</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="221"/>
+        <location filename="../gui/configuration_dialog.cpp" line="222"/>
         <source>Previous highlighted step</source>
         <translation>前のハイライトステップへ移動</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="222"/>
+        <location filename="../gui/configuration_dialog.cpp" line="223"/>
         <source>Next highlighted step</source>
         <translation>次のハイライトステップへ移動</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="223"/>
+        <location filename="../gui/configuration_dialog.cpp" line="224"/>
         <source>Increase pattern size</source>
         <translation>パターン長を増加</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="224"/>
+        <location filename="../gui/configuration_dialog.cpp" line="225"/>
         <source>Decrease pattern size</source>
         <translation>パターン長を縮小</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="225"/>
+        <location filename="../gui/configuration_dialog.cpp" line="226"/>
         <source>Increase edit step</source>
         <translation>エディットステップを増加</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="226"/>
+        <location filename="../gui/configuration_dialog.cpp" line="227"/>
         <source>Decrease edit step</source>
         <translation>エディットステップを減少</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="227"/>
+        <location filename="../gui/configuration_dialog.cpp" line="228"/>
         <source>Display effect list</source>
         <translation>エフェクト一覧を表示</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="228"/>
+        <location filename="../gui/configuration_dialog.cpp" line="229"/>
         <source>Previous song</source>
         <translation>前のソングに切り替え</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="229"/>
+        <location filename="../gui/configuration_dialog.cpp" line="230"/>
         <source>Next song</source>
         <translation>次のソングに切り替え</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="230"/>
+        <location filename="../gui/configuration_dialog.cpp" line="231"/>
         <source>Jam volume up</source>
         <translation>ジャム音量を上げる</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="231"/>
+        <location filename="../gui/configuration_dialog.cpp" line="232"/>
         <source>Jam volume down</source>
         <translation>ジャム音量を下げる</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="314"/>
+        <location filename="../gui/configuration_dialog.cpp" line="315"/>
         <source>None</source>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="510"/>
+        <location filename="../gui/configuration_dialog.cpp" line="511"/>
         <source>Description: %1</source>
         <translation>説明: %1</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="604"/>
+        <location filename="../gui/configuration_dialog.cpp" line="605"/>
         <source>Set %1</source>
         <translation>セット%1</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="746"/>
+        <location filename="../gui/configuration_dialog.cpp" line="747"/>
         <source>Open color scheme</source>
         <translation>カラースキームの読み込み</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="748"/>
-        <location filename="../gui/configuration_dialog.cpp" line="768"/>
+        <location filename="../gui/configuration_dialog.cpp" line="749"/>
+        <location filename="../gui/configuration_dialog.cpp" line="769"/>
         <source>ini file (*.ini)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="748"/>
-        <location filename="../gui/configuration_dialog.cpp" line="768"/>
+        <location filename="../gui/configuration_dialog.cpp" line="749"/>
+        <location filename="../gui/configuration_dialog.cpp" line="769"/>
         <source>All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="760"/>
-        <location filename="../gui/configuration_dialog.cpp" line="779"/>
+        <location filename="../gui/configuration_dialog.cpp" line="761"/>
+        <location filename="../gui/configuration_dialog.cpp" line="780"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="760"/>
+        <location filename="../gui/configuration_dialog.cpp" line="761"/>
         <source>An unknown error occurred while loading the color scheme.</source>
         <translation>カラースキームの読み込み中に不明なエラーが発生しました。</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="766"/>
+        <location filename="../gui/configuration_dialog.cpp" line="767"/>
         <source>Save color scheme</source>
         <translation>カラースキームの保存</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="779"/>
+        <location filename="../gui/configuration_dialog.cpp" line="780"/>
         <source>Failed to save the color scheme.</source>
         <translation>カラースキームの保存に失敗しました。</translation>
     </message>
@@ -1371,122 +1371,122 @@
 <context>
     <name>EffectDescription</name>
     <message>
-        <location filename="../gui/effect_description.cpp" line="43"/>
+        <location filename="../gui/effect_description.cpp" line="42"/>
         <source>Arpeggio, x: 2nd note (0-F), y: 3rd note (0-F)</source>
         <translation>アルペジオ, x: 第2音(0-F), y: 第3音(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="44"/>
+        <location filename="../gui/effect_description.cpp" line="43"/>
         <source>Portamento up, xx: depth (00-FF)</source>
         <translation>ポルタメント・アップ, xx: デプス(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="45"/>
+        <location filename="../gui/effect_description.cpp" line="44"/>
         <source>Portamento down, xx: depth (00-FF)</source>
         <translation>ポルタメント・ダウン, xx: デプス(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="46"/>
+        <location filename="../gui/effect_description.cpp" line="45"/>
         <source>Tone portamento, xx: depth (00-FF)</source>
         <translation>トーン・ポルタメント, xx: デプス(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="47"/>
+        <location filename="../gui/effect_description.cpp" line="46"/>
         <source>Vibrato, x: period (0-F), y: depth (0-F)</source>
         <translation>ビブラート, x: ピリオド(0-F), y: デプス(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="48"/>
+        <location filename="../gui/effect_description.cpp" line="47"/>
         <source>Tremolo, x: period (0-F), y: depth (0-F)</source>
         <translation>トレモロ, x: ピリオド(0-F), y: デプス(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="49"/>
+        <location filename="../gui/effect_description.cpp" line="48"/>
         <source>Pan, xx: 00 = no sound, 01 = right, 02 = left, 03 = center</source>
         <translation>パン, xx: 00 = 無音, 01 = 右, 02 = 左, 03 = 中央</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="50"/>
+        <location filename="../gui/effect_description.cpp" line="49"/>
         <source>Volume slide, x: up (0-F), y: down (0-F)</source>
         <translation>ボリューム・スライド, x: アップ(0-F), y: ダウン(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="51"/>
+        <location filename="../gui/effect_description.cpp" line="50"/>
         <source>Jump to beginning of order xx</source>
         <translation>オーダーxxの先頭へジャンプ</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="52"/>
+        <location filename="../gui/effect_description.cpp" line="51"/>
         <source>End of song</source>
         <translation>ソングの停止</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="53"/>
+        <location filename="../gui/effect_description.cpp" line="52"/>
         <source>Jump to step xx of next order</source>
         <translation>次のオーダーのステップxxへジャンプ</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="54"/>
+        <location filename="../gui/effect_description.cpp" line="53"/>
         <source>Change speed (xx: 00-1F), change tempo (xx: 20-FF)</source>
         <translation>スピード変更(xx: 00-1F), テンポ変更(xx: 20-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="55"/>
+        <location filename="../gui/effect_description.cpp" line="54"/>
         <source>Note delay, xx: count (00-FF)</source>
         <translation>ノート・ディレイ, xx: カウント(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="56"/>
+        <location filename="../gui/effect_description.cpp" line="55"/>
         <source>Auto envelope, x: shift amount (0-F), y: shape (0-F)</source>
         <translation>オートエンベロープ, x: シフト量(x-8), y: エンベロープ形状(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="57"/>
+        <location filename="../gui/effect_description.cpp" line="56"/>
         <source>Hardware envelope period 1, xx: high byte (00-FF)</source>
         <translation>ハードウェアエンベロープ周期1, xx: 上位バイト(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="58"/>
+        <location filename="../gui/effect_description.cpp" line="57"/>
         <source>Hardware envelope period 2, xx: low byte (00-FF)</source>
         <translation>ハードウェアエンベロープ周期2, xx: 下位バイト(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="59"/>
+        <location filename="../gui/effect_description.cpp" line="58"/>
         <source>Retrigger, x: volume slide (0-7: up, 8-F: down), y: tick (1-F)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="60"/>
+        <location filename="../gui/effect_description.cpp" line="59"/>
         <source>Set groove xx</source>
         <translation>グルーブをxxに設定</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="61"/>
+        <location filename="../gui/effect_description.cpp" line="60"/>
         <source>Detune, xx: pitch (00-FF)</source>
         <translation>デチューン, xx: ピッチ(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="62"/>
+        <location filename="../gui/effect_description.cpp" line="61"/>
         <source>Note slide up, x: count (0-F), y: seminote (0-F)</source>
         <translation>ノート・スライドアップ, x: カウント(0-F), y: 半音数(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="63"/>
+        <location filename="../gui/effect_description.cpp" line="62"/>
         <source>Note slide down, x: count (0-F), y: seminote (0-F)</source>
         <translation>ノート・スライドダウン, x: カウント(0-F), y: 半音数(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="64"/>
+        <location filename="../gui/effect_description.cpp" line="63"/>
         <source>Note cut, xx: count (00-FF)</source>
         <translation type="unfinished">ノート・カット, xx: カウント(01-FF) {00-?}</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="65"/>
+        <location filename="../gui/effect_description.cpp" line="64"/>
         <source>Transpose delay, x: count (0-7: up, 8-F: down), y: seminote (0-F)</source>
         <translation type="unfinished">トランスポーズ・ディレイ, x: カウント(1-7: アップ, 9-F: ダウン), y: 半音数(0-F) {0-7:?} {8-?} {0-?}</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="79"/>
+        <location filename="../gui/effect_description.cpp" line="78"/>
         <source>Volume delay, x: count (0-F), yy: volume (00-FF)</source>
         <translation type="unfinished">ボリューム・ディレイ, x: カウント(1-F), yy: 音量(00-FF) {0-?} {00-?}</translation>
     </message>
@@ -1499,67 +1499,67 @@
         <translation type="vanished">トランスポーズ・ディレイ, x: カウント(1-7: アップ, 9-F: ダウン), y: 半音数(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="66"/>
+        <location filename="../gui/effect_description.cpp" line="65"/>
         <source>Tone/Noise mix, xx: 00 = no sound, 01 = tone, 02 = noise, 03 = tone &amp; noise</source>
         <translation>トーン/ノイズ・ミックス, xx: 00=消音, 01=トーン, 02=ノイズ, 03=トーン &amp; ノイズ</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="67"/>
+        <location filename="../gui/effect_description.cpp" line="66"/>
         <source>Master volume, xx: volume (00-3F)</source>
         <translation>マスターボリューム, xx: 音量(00-3F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="68"/>
+        <location filename="../gui/effect_description.cpp" line="67"/>
         <source>Noise pitch, xx: pitch (00-1F)</source>
         <translation>ノイズ・ピッチ, xx: ピッチ(00-1F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="69"/>
+        <location filename="../gui/effect_description.cpp" line="68"/>
         <source>Register address bank 0, xx: address (00-6B)</source>
         <translation>レジスタ番地指定 バンク0, xx: 番地(00-B6)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="70"/>
+        <location filename="../gui/effect_description.cpp" line="69"/>
         <source>Register address bank 1, xx: address (00-6B)</source>
         <translation>レジスタ番地指定 バンク1, xx: 番地(00-B6)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="71"/>
+        <location filename="../gui/effect_description.cpp" line="70"/>
         <source>Register value set, xx: value (00-FF)</source>
         <translation>レジスタ値指定, xx: レジスタ値(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="72"/>
+        <location filename="../gui/effect_description.cpp" line="71"/>
         <source>AR control, x: operator (1-4), yy: attack rate (00-1F)</source>
         <translation>ARコントロール, x: オペレーター(1-4), yy: AR値(00-1F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="73"/>
+        <location filename="../gui/effect_description.cpp" line="72"/>
         <source>Brightness, xx: relative value (01-FF)</source>
         <translation>ブライトネス, xx: 相対値(01-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="74"/>
+        <location filename="../gui/effect_description.cpp" line="73"/>
         <source>DR control, x: operator (1-4), yy: decay rate (00-1F)</source>
         <translation>DRコントロール, x: オペレーター(1-4), yy: DR値(00-1F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="75"/>
+        <location filename="../gui/effect_description.cpp" line="74"/>
         <source>Envelope reset, xx: count (00-FF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="76"/>
+        <location filename="../gui/effect_description.cpp" line="75"/>
         <source>FB control, xx: feedback value (00-07)</source>
         <translation>FBコントロール, xx: フィードバック値(00-07)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="77"/>
+        <location filename="../gui/effect_description.cpp" line="76"/>
         <source>Fine detune, xx: pitch (00-FF)</source>
         <translation>ファイン・デチューン, xx: ピッチ(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="78"/>
+        <location filename="../gui/effect_description.cpp" line="77"/>
         <source>ML control, x: operator (1-4), y: multiple (0-F)</source>
         <translation>MLコントロール, x: オペレーター(1-4), y: ML値(0-F)</translation>
     </message>
@@ -1568,17 +1568,17 @@
         <translation type="vanished">ボリューム・ディレイ, x: カウント(1-F), yy: 音量(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="80"/>
+        <location filename="../gui/effect_description.cpp" line="79"/>
         <source>RR control, x: operator (1-4), y: release rate (0-F)</source>
         <translation>RRコントロール, x: オペレーター(1-4), y: RR値(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="81"/>
+        <location filename="../gui/effect_description.cpp" line="80"/>
         <source>TL control, x: operator (1-4), yy: total level (00-7F)</source>
         <translation>TLコントロール, x: オペレーター(1-4), yy: TL値(00-7F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="82"/>
+        <location filename="../gui/effect_description.cpp" line="81"/>
         <source>Invalid effect</source>
         <translation>無効なエフェクト</translation>
     </message>
@@ -1719,42 +1719,42 @@
         <translation type="vanished">インストゥルメント</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="54"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="55"/>
         <source>Path does not exist.</source>
         <translation>指定されたパスが存在しません。</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="57"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="58"/>
         <source>Unsupported file format.</source>
         <translation>非対応のファイルフォーマットです。</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="60"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="61"/>
         <source>Could not load the %1 properly. Please make sure that you have the latest version of BambooTracker.</source>
         <translation>%1を読み込めませんでした。最新版のBambooTrackerで読み込みを行なってください。</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="64"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="65"/>
         <source>Could not load the %1. It may be corrupted. Stopped at %2.</source>
         <translation>%1を読み込めませんでした。ファイルが破損している可能性があります。停止ポイント: %2。</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="73"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="74"/>
         <source>Failed to load %1.</source>
         <translation>%1の読み込みに失敗しました。</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="80"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="81"/>
         <source>Failed to export to %1.</source>
         <translation>%1の書き出しに失敗しました。</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="83"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="84"/>
         <source>Failed to save the %1.</source>
         <translation>%1の保存に失敗しました。</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="92"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="93"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
@@ -1767,32 +1767,32 @@
 <context>
     <name>FileType</name>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="32"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="33"/>
         <source>module</source>
         <translation type="unfinished">モジュール</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="33"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="34"/>
         <source>s98</source>
         <translation type="unfinished">S98</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="34"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="35"/>
         <source>vgm</source>
         <translation type="unfinished">VGM</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="35"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="36"/>
         <source>wav</source>
         <translation type="unfinished">WAV</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="36"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="37"/>
         <source>bank</source>
         <translation type="unfinished">バンク</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="37"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="38"/>
         <source>instrument</source>
         <translation type="unfinished">インストゥルメント</translation>
     </message>
@@ -2449,16 +2449,16 @@
         <translation>テンポ</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2066"/>
-        <location filename="../gui/mainwindow.cpp" line="2521"/>
-        <location filename="../gui/mainwindow.cpp" line="2523"/>
-        <location filename="../gui/mainwindow.cpp" line="2549"/>
+        <location filename="../gui/mainwindow.cpp" line="2061"/>
+        <location filename="../gui/mainwindow.cpp" line="2516"/>
+        <location filename="../gui/mainwindow.cpp" line="2518"/>
+        <location filename="../gui/mainwindow.cpp" line="2544"/>
         <source>Untitled</source>
         <translation>無題</translation>
     </message>
     <message>
         <location filename="../gui/mainwindow.ui" line="244"/>
-        <location filename="../gui/mainwindow.cpp" line="3693"/>
+        <location filename="../gui/mainwindow.cpp" line="3688"/>
         <source>Groove</source>
         <translation>グルーブ</translation>
     </message>
@@ -3294,14 +3294,14 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="267"/>
+        <location filename="../gui/mainwindow.cpp" line="262"/>
         <source>Octave</source>
         <translation>オクターブ</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="280"/>
-        <location filename="../gui/mainwindow.cpp" line="541"/>
-        <location filename="../gui/mainwindow.cpp" line="2331"/>
+        <location filename="../gui/mainwindow.cpp" line="275"/>
+        <location filename="../gui/mainwindow.cpp" line="536"/>
+        <location filename="../gui/mainwindow.cpp" line="2326"/>
         <source>Octave: %1</source>
         <oldsource>Octave: </oldsource>
         <translation>オクターブ: %1</translation>
@@ -3312,381 +3312,381 @@
         <translation type="vanished">%1の変更を保存しますか?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2509"/>
-        <location filename="../gui/mainwindow.hpp" line="234"/>
-        <location filename="../gui/mainwindow.hpp" line="250"/>
+        <location filename="../gui/mainwindow.cpp" line="2504"/>
+        <location filename="../gui/mainwindow.hpp" line="243"/>
+        <location filename="../gui/mainwindow.hpp" line="259"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1353"/>
-        <location filename="../gui/mainwindow.cpp" line="1374"/>
+        <location filename="../gui/mainwindow.cpp" line="1348"/>
+        <location filename="../gui/mainwindow.cpp" line="1369"/>
         <source>Instrument %1</source>
         <oldsource>Instrument </oldsource>
         <translation>インストゥルメント%1</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="543"/>
+        <location filename="../gui/mainwindow.cpp" line="538"/>
         <source>Welcome to BambooTracker v%1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1705"/>
+        <location filename="../gui/mainwindow.cpp" line="1700"/>
         <source>Open instrument</source>
         <translation>インストゥルメントを開く</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1769"/>
+        <location filename="../gui/mainwindow.cpp" line="1764"/>
         <source>Save instrument</source>
         <translation>インストゥルメント保存</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1815"/>
+        <location filename="../gui/mainwindow.cpp" line="1810"/>
         <source>Open bank</source>
         <translation>バンクを開く</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1879"/>
+        <location filename="../gui/mainwindow.cpp" line="1874"/>
         <source>Select instruments to load:</source>
         <translation>読み込むインストゥルメントを選択:</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2538"/>
-        <location filename="../gui/mainwindow.cpp" line="2588"/>
+        <location filename="../gui/mainwindow.cpp" line="2533"/>
+        <location filename="../gui/mainwindow.cpp" line="2583"/>
         <source>No instrument</source>
         <translation>インストゥルメントなし</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2228"/>
+        <location filename="../gui/mainwindow.cpp" line="2223"/>
         <source>Standard</source>
         <translation>標準</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="174"/>
+        <location filename="../gui/mainwindow.cpp" line="169"/>
         <source>English</source>
         <comment>Default notation system</comment>
         <extracomment>Set the name of suitable notation system (English or German)</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="283"/>
+        <location filename="../gui/mainwindow.cpp" line="278"/>
         <source>Volume</source>
         <translation>音量</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="300"/>
+        <location filename="../gui/mainwindow.cpp" line="295"/>
         <source>Step highlight 1st</source>
         <translation>ステップハイライト 1st</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="316"/>
+        <location filename="../gui/mainwindow.cpp" line="311"/>
         <source>2nd</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="683"/>
+        <location filename="../gui/mainwindow.cpp" line="678"/>
         <source>Welcome to BambooTracker!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="687"/>
+        <location filename="../gui/mainwindow.cpp" line="682"/>
         <source>Don&apos;t know where to start?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="688"/>
+        <location filename="../gui/mainwindow.cpp" line="683"/>
         <source>Check the demo modules and instruments included with your download of BambooTracker.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="690"/>
+        <location filename="../gui/mainwindow.cpp" line="685"/>
         <source>Need a list of effects and shortcuts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="691"/>
+        <location filename="../gui/mainwindow.cpp" line="686"/>
         <source>Check the Help menu at the top of the window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="692"/>
+        <location filename="../gui/mainwindow.cpp" line="687"/>
         <source>Still lost?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="693"/>
+        <location filename="../gui/mainwindow.cpp" line="688"/>
         <source>The README.md has a link to our Discord server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="694"/>
+        <location filename="../gui/mainwindow.cpp" line="689"/>
         <source>Think you&apos;ve found a bug? Missing a feature?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="695"/>
+        <location filename="../gui/mainwindow.cpp" line="690"/>
         <source>BambooTracker is still in development, bugs and missing features are to be expected. So we need your help!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="699"/>
+        <location filename="../gui/mainwindow.cpp" line="694"/>
         <source>Please report any bugs you find and requests and features you&apos;d like to see on our Discord server or our bug tracker (%1).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="703"/>
+        <location filename="../gui/mainwindow.cpp" line="698"/>
         <source>If you&apos;re a developer yourself or would like to start being one, consider contributing to the project yourself. Any help would be appreciated!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="707"/>
+        <location filename="../gui/mainwindow.cpp" line="702"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1724"/>
-        <location filename="../gui/mainwindow.cpp" line="1936"/>
+        <location filename="../gui/mainwindow.cpp" line="1719"/>
+        <location filename="../gui/mainwindow.cpp" line="1931"/>
         <source>The number of instruments has reached the upper limit.</source>
         <translation>インストゥルメント数が上限に達しています。</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1968"/>
+        <location filename="../gui/mainwindow.cpp" line="1963"/>
         <source>Select instruments to save:</source>
         <translation>保存するインストゥルメントを選択:</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1979"/>
+        <location filename="../gui/mainwindow.cpp" line="1974"/>
         <source>Save bank</source>
         <translation>バンク保存</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2095"/>
+        <location filename="../gui/mainwindow.cpp" line="2090"/>
         <source>-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2100"/>
+        <location filename="../gui/mainwindow.cpp" line="2095"/>
         <source>Custom</source>
         <translation>カスタム</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2105"/>
+        <location filename="../gui/mainwindow.cpp" line="2100"/>
         <source>PC-9821 with PC-9801-86</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2110"/>
+        <location filename="../gui/mainwindow.cpp" line="2105"/>
         <source>PC-9821 with Speak Board</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2115"/>
+        <location filename="../gui/mainwindow.cpp" line="2110"/>
         <source>PC-88VA2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2120"/>
+        <location filename="../gui/mainwindow.cpp" line="2115"/>
         <source>NEC PC-8801mkIISR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2229"/>
+        <location filename="../gui/mainwindow.cpp" line="2224"/>
         <source>FM3ch expanded</source>
         <translation>FM3ch拡張</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2258"/>
+        <location filename="../gui/mainwindow.cpp" line="2253"/>
         <source>Insufficient memory size to load ADPCM samples. Please delete the unused samples.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2409"/>
+        <location filename="../gui/mainwindow.cpp" line="2404"/>
         <source>The module has been changed. Do you want to save it?</source>
         <translation>モジュールが変更されています。保存しますか?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.hpp" line="251"/>
+        <location filename="../gui/mainwindow.hpp" line="260"/>
         <source>Could not initialize MIDI input.</source>
         <translation>MIDI Inを初期化できませんでした。</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3196"/>
-        <location filename="../gui/mainwindow.cpp" line="3262"/>
+        <location filename="../gui/mainwindow.cpp" line="3191"/>
+        <location filename="../gui/mainwindow.cpp" line="3257"/>
         <source>BambooTracker module (*.btm)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3196"/>
-        <location filename="../gui/mainwindow.cpp" line="3262"/>
-        <location filename="../gui/mainwindow.cpp" line="3383"/>
-        <location filename="../gui/mainwindow.cpp" line="3518"/>
-        <location filename="../gui/mainwindow.cpp" line="3586"/>
+        <location filename="../gui/mainwindow.cpp" line="3191"/>
+        <location filename="../gui/mainwindow.cpp" line="3257"/>
+        <location filename="../gui/mainwindow.cpp" line="3378"/>
+        <location filename="../gui/mainwindow.cpp" line="3513"/>
+        <location filename="../gui/mainwindow.cpp" line="3581"/>
         <source>All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3383"/>
+        <location filename="../gui/mainwindow.cpp" line="3378"/>
         <source>WAV signed 16-bit PCM (*.wav)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3421"/>
+        <location filename="../gui/mainwindow.cpp" line="3416"/>
         <source>Export %1 to WAV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3518"/>
+        <location filename="../gui/mainwindow.cpp" line="3513"/>
         <source>VGM file (*.vgm)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3586"/>
+        <location filename="../gui/mainwindow.cpp" line="3581"/>
         <source>S98 file (*.s98)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3753"/>
+        <location filename="../gui/mainwindow.cpp" line="3748"/>
         <source>Do you want to remove all duplicate instruments?</source>
         <translation>重複したインストゥルメントを削除しますか?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3856"/>
+        <location filename="../gui/mainwindow.cpp" line="3851"/>
         <source>Do you want to remove all unused ADPCM samples?</source>
         <translation>未使用のADPCMサンプルを削除しますか?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3899"/>
+        <location filename="../gui/mainwindow.cpp" line="3894"/>
         <source>Do you want to transpose a song?</source>
         <translation>ソングをトランスポーズしますか?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3920"/>
+        <location filename="../gui/mainwindow.cpp" line="3915"/>
         <source>Do you want to swap tracks?</source>
         <translation>トラックを入れ替えますか?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3974"/>
+        <location filename="../gui/mainwindow.cpp" line="3969"/>
         <source>Approximate song length: %1m%2s</source>
         <translation>ソングの長さ: %1分%2秒</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2590"/>
+        <location filename="../gui/mainwindow.cpp" line="2585"/>
         <source>Instrument: %1</source>
         <oldsource>Instrument: </oldsource>
         <translation>インストゥルメント: %1</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2881"/>
+        <location filename="../gui/mainwindow.cpp" line="2876"/>
         <source>Do you want to change song properties?</source>
         <translation>ソング情報を変更しますか?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2957"/>
+        <location filename="../gui/mainwindow.cpp" line="2952"/>
         <source>Change to jam mode</source>
         <translation>ジャムモードに切り替え</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2957"/>
+        <location filename="../gui/mainwindow.cpp" line="2952"/>
         <source>Change to edit mode</source>
         <translation>編集モードに切り替え</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2979"/>
+        <location filename="../gui/mainwindow.cpp" line="2974"/>
         <source>YM2608 Music Tracker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2981"/>
+        <location filename="../gui/mainwindow.cpp" line="2976"/>
         <source>Web:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2984"/>
+        <location filename="../gui/mainwindow.cpp" line="2979"/>
         <source>This software is licensed under the GNU General Public License v2.0 or later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2985"/>
+        <location filename="../gui/mainwindow.cpp" line="2980"/>
         <source>Source is available at:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2988"/>
+        <location filename="../gui/mainwindow.cpp" line="2983"/>
         <source>Libraries:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2989"/>
+        <location filename="../gui/mainwindow.cpp" line="2984"/>
         <source>Also see changelog which lists contributors.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2990"/>
+        <location filename="../gui/mainwindow.cpp" line="2985"/>
         <source>Thank you to everyone who reports bugs, makes suggestions, and contributes to this project!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2994"/>
+        <location filename="../gui/mainwindow.cpp" line="2989"/>
         <source>C86CTL by (C) honet (BSD 3-Clause)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2996"/>
+        <location filename="../gui/mainwindow.cpp" line="2991"/>
         <source>emu2149 by (C) Mitsutaka Okazaki (MIT License)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2997"/>
+        <location filename="../gui/mainwindow.cpp" line="2992"/>
         <source>fmopn by (C) Tatsuyuki Satoh, Jarek Burczynski, ValleyBell (GPL v2+)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2998"/>
+        <location filename="../gui/mainwindow.cpp" line="2993"/>
         <source>libOPNMIDI by (C) Vitaly Novichkov (MIT License part)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2999"/>
+        <location filename="../gui/mainwindow.cpp" line="2994"/>
         <source>Nuked OPN-MOD by (C) Alexey Khokholov (Nuke.YKT), Jean Pierre Cimalando (LGPL v2.1+)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3000"/>
+        <location filename="../gui/mainwindow.cpp" line="2995"/>
         <source>Qt (GPL v2+ or LGPL v3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3001"/>
+        <location filename="../gui/mainwindow.cpp" line="2996"/>
         <source>RtAudio by (C) Gary P. Scavone (RtAudio License)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3002"/>
+        <location filename="../gui/mainwindow.cpp" line="2997"/>
         <source>RtMidi by (C) Gary P. Scavone (RtMidi License)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3004"/>
+        <location filename="../gui/mainwindow.cpp" line="2999"/>
         <source>SCCI by (C) gasshi (SCCI License)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3006"/>
+        <location filename="../gui/mainwindow.cpp" line="3001"/>
         <source>Silk icons by (C) Mark James (CC BY 2.5 or 3.0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3007"/>
+        <location filename="../gui/mainwindow.cpp" line="3002"/>
         <source>ymdeltat by (C) Tatsuyuki Satoh, Jarek Burczynski, ValleyBell (GPL v2+)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3024"/>
+        <location filename="../gui/mainwindow.cpp" line="3019"/>
         <source>About</source>
         <translation>バージョン情報</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2509"/>
+        <location filename="../gui/mainwindow.cpp" line="2504"/>
         <source>Failed to backup module.</source>
         <translation>モジュールのバックアップ作成に失敗しました。</translation>
     </message>
@@ -3695,70 +3695,70 @@
         <translation type="vanished">&lt;b&gt;YM2608 (OPNA) Music Tracker&lt;br&gt;Copyright (C) 2018-2020 Rerrah&lt;/b&gt;&lt;br&gt;&lt;hr&gt;使用ライブラリ:&lt;br&gt;- C86CTL by (C) honet (BSD 3-Clause)&lt;br&gt;- libOPNMIDI by (C) Vitaly Novichkov (MIT License part)&lt;br&gt;- MAME (MAME License)&lt;br&gt;- Nuked OPN-MOD by (C) Alexey Khokholov (Nuke.YKT)&lt;br&gt;and (C) Jean Pierre Cimalando (LGPL v2.1)&lt;br&gt;- RtAudio by (C) Gary P. Scavone (RtAudio License)&lt;br&gt;- RtMidi by (C) Gary P. Scavone (RtMidi License)&lt;br&gt;- SCCI by (C) gasshi (SCCI License)&lt;br&gt;- Silk icons by (C) Mark James (CC BY 2.5 or 3.0)&lt;br&gt;- Qt (GPL v2+ or LGPL v3)&lt;br&gt;- VGMPlay by (C) Valley Bell (GPL v2)&lt;br&gt;&lt;br&gt;このプロジェクトのコントリビューターについてはChangelogもご覧ください。</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3194"/>
+        <location filename="../gui/mainwindow.cpp" line="3189"/>
         <source>Save module</source>
         <translation>モジュール保存</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3261"/>
+        <location filename="../gui/mainwindow.cpp" line="3256"/>
         <source>Open module</source>
         <translation>モジュールを開く</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3331"/>
+        <location filename="../gui/mainwindow.cpp" line="3326"/>
         <source>Do you want to remove all unused instruments?</source>
         <translation>未使用のインストゥルメントを削除しますか?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3352"/>
+        <location filename="../gui/mainwindow.cpp" line="3347"/>
         <source>Do you want to remove all unused patterns?</source>
         <translation>未使用のパターンを削除しますか?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3381"/>
-        <location filename="../gui/mainwindow.cpp" line="3415"/>
+        <location filename="../gui/mainwindow.cpp" line="3376"/>
+        <location filename="../gui/mainwindow.cpp" line="3410"/>
         <source>Export to WAV</source>
         <translation>WAV書き出し</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3394"/>
-        <location filename="../gui/mainwindow.cpp" line="3527"/>
-        <location filename="../gui/mainwindow.cpp" line="3595"/>
+        <location filename="../gui/mainwindow.cpp" line="3389"/>
+        <location filename="../gui/mainwindow.cpp" line="3522"/>
+        <location filename="../gui/mainwindow.cpp" line="3590"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3516"/>
-        <location filename="../gui/mainwindow.cpp" line="3527"/>
+        <location filename="../gui/mainwindow.cpp" line="3511"/>
+        <location filename="../gui/mainwindow.cpp" line="3522"/>
         <source>Export to VGM</source>
         <translation>VGM書き出し</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3584"/>
-        <location filename="../gui/mainwindow.cpp" line="3595"/>
+        <location filename="../gui/mainwindow.cpp" line="3579"/>
+        <location filename="../gui/mainwindow.cpp" line="3590"/>
         <source>Export to S98</source>
         <translation>S98書き出し</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2257"/>
-        <location filename="../gui/mainwindow.cpp" line="2408"/>
-        <location filename="../gui/mainwindow.hpp" line="226"/>
-        <location filename="../gui/mainwindow.hpp" line="242"/>
+        <location filename="../gui/mainwindow.cpp" line="2252"/>
+        <location filename="../gui/mainwindow.cpp" line="2403"/>
+        <location filename="../gui/mainwindow.hpp" line="235"/>
+        <location filename="../gui/mainwindow.hpp" line="251"/>
         <source>Warning</source>
         <translation>注意</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.hpp" line="227"/>
+        <location filename="../gui/mainwindow.hpp" line="236"/>
         <source>%1 If you execute this command, the command history is reset.</source>
         <translation>%1この操作を実行すると、すべてのコマンド履歴は消去されます。</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.hpp" line="235"/>
+        <location filename="../gui/mainwindow.hpp" line="244"/>
         <source>Could not open the audio stream. Please change the sound settings in Configuration.</source>
         <translation>オーディオストリームを開けませんでした。環境設定でサウンド設定を変更してください。</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.hpp" line="243"/>
+        <location filename="../gui/mainwindow.hpp" line="252"/>
         <source>Could not set the sample rate of the audio stream to %1Hz. Currently the stream runs on %2Hz instead.</source>
         <translation>オーディオ出力のサンプルレートを%1Hzに設定できませんでした。一時的に%2Hzで出力します。</translation>
     </message>
@@ -3895,12 +3895,12 @@
 <context>
     <name>ModuleSaveCheckDialog</name>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="108"/>
+        <location filename="../gui/mainwindow.cpp" line="105"/>
         <source>Save changes to %1?</source>
         <translation type="unfinished">%1の変更を保存しますか?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="108"/>
+        <location filename="../gui/mainwindow.cpp" line="105"/>
         <source>Untitled</source>
         <translation type="unfinished">無題</translation>
     </message>
@@ -3908,12 +3908,12 @@
 <context>
     <name>NotationSystem</name>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="71"/>
+        <location filename="../gui/configuration_dialog.cpp" line="72"/>
         <source>English</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="72"/>
+        <location filename="../gui/configuration_dialog.cpp" line="73"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3983,17 +3983,17 @@
 <context>
     <name>Panning</name>
     <message>
-        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="40"/>
+        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="41"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="41"/>
+        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="42"/>
         <source>Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="42"/>
+        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="43"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4366,12 +4366,12 @@
 <context>
     <name>SongType</name>
     <message>
-        <location filename="../gui/module_properties_dialog.cpp" line="37"/>
+        <location filename="../gui/module_properties_dialog.cpp" line="38"/>
         <source>Standard</source>
         <translation type="unfinished">標準</translation>
     </message>
     <message>
-        <location filename="../gui/module_properties_dialog.cpp" line="38"/>
+        <location filename="../gui/module_properties_dialog.cpp" line="39"/>
         <source>FM3ch expanded</source>
         <translation type="unfinished">FM3ch拡張</translation>
     </message>

--- a/BambooTracker/lang/bamboo_tracker_pl.ts
+++ b/BambooTracker/lang/bamboo_tracker_pl.ts
@@ -238,7 +238,7 @@
     <name>ConfigurationDialog</name>
     <message>
         <location filename="../gui/configuration_dialog.ui" line="14"/>
-        <location filename="../gui/configuration_dialog.cpp" line="499"/>
+        <location filename="../gui/configuration_dialog.cpp" line="500"/>
         <source>Configuration</source>
         <translation>Konfiguracja</translation>
     </message>
@@ -715,22 +715,22 @@
         <translation>Wysokie</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="163"/>
+        <location filename="../gui/configuration_dialog.cpp" line="164"/>
         <source>Key off</source>
         <translation>Puszczony klawisz</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="164"/>
+        <location filename="../gui/configuration_dialog.cpp" line="165"/>
         <source>Octave up</source>
         <translation>Oktawa w górę</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="165"/>
+        <location filename="../gui/configuration_dialog.cpp" line="166"/>
         <source>Octave down</source>
         <translation>Oktawa w dół</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="166"/>
+        <location filename="../gui/configuration_dialog.cpp" line="167"/>
         <source>Echo buffer</source>
         <translation>Bufor echa</translation>
     </message>
@@ -879,491 +879,491 @@
         <translation>Resetuj</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="584"/>
+        <location filename="../gui/configuration_dialog.cpp" line="585"/>
         <source>Virtual port</source>
         <translation>Wirtualny port</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="360"/>
+        <location filename="../gui/configuration_dialog.cpp" line="361"/>
         <source>Master</source>
         <translation>Główny</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="499"/>
+        <location filename="../gui/configuration_dialog.cpp" line="500"/>
         <source>The change of emulator will be effective after restarting the program.</source>
         <translation>Zmiana emulatora dokona się po restarcie programu.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="102"/>
+        <location filename="../gui/configuration_dialog.cpp" line="103"/>
         <source>Warp the cursor around the edges of the pattern editor.</source>
         <translation>Przemieszcza kursor wokół krańców edytora wzorców.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="104"/>
+        <location filename="../gui/configuration_dialog.cpp" line="105"/>
         <source>Move to previous or next order when reaching top or bottom in the pattern editor.</source>
         <translation>Przechodzi do poprzedniej lub następnej klatki po osiągnięciu początku lub końca wzorca.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="106"/>
+        <location filename="../gui/configuration_dialog.cpp" line="107"/>
         <source>Display row numbers and the playback position on the status bar in hexadecimal.</source>
         <translation>Wyświetla numery wierszów i pozycję odtwarzania na pasku stanu w systemie szesnastkowym.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="108"/>
+        <location filename="../gui/configuration_dialog.cpp" line="109"/>
         <source>Preview previous and next orders in the pattern editor.</source>
         <translation>Pokazuje fragmenty poprzednich i następnych klatek w edytorze wzorców.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="110"/>
+        <location filename="../gui/configuration_dialog.cpp" line="111"/>
         <source>Create a backup copy of the existing file when saving a module.</source>
         <translation>Tworzy kopię zapasową istniejącego pliku podczas zapisywania modułów.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="112"/>
+        <location filename="../gui/configuration_dialog.cpp" line="113"/>
         <source>Don&apos;t select the whole track when double-clicking in the pattern editor.</source>
         <translation>Nie zaznacza całego kanału poprzez podwójne kliknięcie w edytorze wzorców.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="114"/>
+        <location filename="../gui/configuration_dialog.cpp" line="115"/>
         <source>Reverse the order of FM volume so that 00 is the quietest in the pattern editor.</source>
         <oldsource>Reverse the order of FM volume so that 00 is the quietest in the pattern editor</oldsource>
         <translation>Odwraca kolejność poziomów głośności FM w edytorze wzorców w taki sposób, że 00 jest najcichszym ustawieniem.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="116"/>
+        <location filename="../gui/configuration_dialog.cpp" line="117"/>
         <source>Move the cursor to right after entering effects in the pattern editor.</source>
         <translation>Kursor zostanie przesunięty w prawo po wpisaniu efektu w edytorze wzorców.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="118"/>
+        <location filename="../gui/configuration_dialog.cpp" line="119"/>
         <source>Reconstruct the current channel&apos;s state from previous orders upon playing.</source>
         <translation>Rekonstruuje stan aktualnego kanału podczas odtwarzania przy pomocy danych z poprzednich klatek. </translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="120"/>
+        <location filename="../gui/configuration_dialog.cpp" line="121"/>
         <source>Translate to your language from the next launch. See readme to check supported languages.</source>
         <translation>Włącza tłumaczenie na twój język przy następnym uruchomieniu. Sprawdź plik readme by dowiedzieć się o obsługiwanych językach.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="122"/>
+        <location filename="../gui/configuration_dialog.cpp" line="123"/>
         <source>Display FM detune values as signed numbers in the FM envelope editor.</source>
         <translation>Pokazuje wartości rozstroju FM jako jako liczby ze znakiem w edytorze obwiedni FM.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="124"/>
+        <location filename="../gui/configuration_dialog.cpp" line="125"/>
         <source>Fill 00 to effect value column upon entering effect id.</source>
         <translation>Dodaje 00 do kolumny wartości efektów po wpisaniu ID efektu.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="126"/>
+        <location filename="../gui/configuration_dialog.cpp" line="127"/>
         <source>Move the cursor position by cell with horizontal scroll bar in the order list and the pattern editor.</source>
         <translation>Przesuwa pozycję kursora o komórkę przy pomocy pionowego paska przewijania w liscie klatek i w edytorze wzorców.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="128"/>
+        <location filename="../gui/configuration_dialog.cpp" line="129"/>
         <source>Overwrite unused and unedited instrument properties on creating new properties. When disabled, override unused properties regardless of editing.</source>
         <translation>Nadpisuje nieużywane i niezedytowane właściwości instrumentu przy tworzeniu nowych właściwości. Gdy wyłączone, nieużywane właściwości bedą zastępowane niezależnie od tego, czy były edytowane.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="131"/>
+        <location filename="../gui/configuration_dialog.cpp" line="132"/>
         <source>Send only ADPCM samples used by instruments to the ADPCM memory. Recommend to turn off if you change ADPCM samples frequently due to take the high rewriting cost.</source>
         <translation>Wysyła do pamięci ADPCM tylko próbki używane przez instrumenty. Zalecane jest wyłączenie tej opcji jeżeli często zmieniasz próbki ADPCM ze względu na długi czas nadpsywania. </translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="134"/>
+        <location filename="../gui/configuration_dialog.cpp" line="135"/>
         <source>Correspond the instrument number in patterns when the instrument changes its number.</source>
         <translation>Podmienia numer instrumentu we wzorcach gdy instrument zmieni swój numer.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="136"/>
+        <location filename="../gui/configuration_dialog.cpp" line="137"/>
         <source>Set maximum volume during jam mode. When unchecked, the volume is changed by the volume spinbox.</source>
         <translation>Ustawia maksymalną głośność poczas trybu improwizacji. Gdy odznaczone, głośność jest zmieniana przy pomocy selektora głośńości.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="138"/>
+        <location filename="../gui/configuration_dialog.cpp" line="139"/>
         <source>Mute hidden tracks when visibility of tracks is changed.</source>
         <translation>Wycisza ukryte kanały kiedy widoczność tych kanałów jest zmieniona.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="140"/>
+        <location filename="../gui/configuration_dialog.cpp" line="141"/>
         <source>Restore the previous track visibility on startup.</source>
         <translation>Przywraca poprzednią widoczność kanałów przy następnym uruchomieniu.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="167"/>
+        <location filename="../gui/configuration_dialog.cpp" line="168"/>
         <source>Play and stop</source>
         <translation>Odtwórz i zatrzymaj</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="168"/>
+        <location filename="../gui/configuration_dialog.cpp" line="169"/>
         <source>Play</source>
         <translation>Odtwarzaj</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="169"/>
+        <location filename="../gui/configuration_dialog.cpp" line="170"/>
         <source>Play from start</source>
         <translation>Odtwarzaj od początku</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="170"/>
+        <location filename="../gui/configuration_dialog.cpp" line="171"/>
         <source>Play pattern</source>
         <translation>Odtwarzaj wzorzec</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="171"/>
+        <location filename="../gui/configuration_dialog.cpp" line="172"/>
         <source>Play from cursor</source>
         <translation>Odtwarzaj od kursora</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="172"/>
+        <location filename="../gui/configuration_dialog.cpp" line="173"/>
         <source>Play from marker</source>
         <translation>Odtwarzaj od znacznika</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="173"/>
+        <location filename="../gui/configuration_dialog.cpp" line="174"/>
         <source>Play step</source>
         <translation>Odtwórz krok</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="174"/>
+        <location filename="../gui/configuration_dialog.cpp" line="175"/>
         <source>Stop</source>
         <translation>Zatrzymaj</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="175"/>
+        <location filename="../gui/configuration_dialog.cpp" line="176"/>
         <source>Focus on pattern editor</source>
         <translation>Skup widok na edytorze wzorców</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="176"/>
+        <location filename="../gui/configuration_dialog.cpp" line="177"/>
         <source>Focus on order list</source>
         <translation>Skup widok na liście klatek</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="177"/>
+        <location filename="../gui/configuration_dialog.cpp" line="178"/>
         <source>Focus on instrument list</source>
         <translation>Skup widok na liście instrumentów</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="178"/>
+        <location filename="../gui/configuration_dialog.cpp" line="179"/>
         <source>Toggle edit/jam mode</source>
         <translation>Włącz tryby Edit/Jam</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="179"/>
+        <location filename="../gui/configuration_dialog.cpp" line="180"/>
         <source>Set marker</source>
         <translation>Ustaw znacznik</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="180"/>
+        <location filename="../gui/configuration_dialog.cpp" line="181"/>
         <source>Paste and mix</source>
         <translation>Wklej i miksuj</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="181"/>
+        <location filename="../gui/configuration_dialog.cpp" line="182"/>
         <source>Paste and overwrite</source>
         <translation>Wklej i nadpisz</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="182"/>
+        <location filename="../gui/configuration_dialog.cpp" line="183"/>
         <source>Paste and insert</source>
         <translation>Wklej i dodaj</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="183"/>
+        <location filename="../gui/configuration_dialog.cpp" line="184"/>
         <source>Select all</source>
         <translation>Zaznacz wszystko</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="184"/>
+        <location filename="../gui/configuration_dialog.cpp" line="185"/>
         <source>Deselect</source>
         <translation>Odznacz</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="185"/>
+        <location filename="../gui/configuration_dialog.cpp" line="186"/>
         <source>Select row</source>
         <translation>Zaznacz wiersz</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="186"/>
+        <location filename="../gui/configuration_dialog.cpp" line="187"/>
         <source>Select column</source>
         <translation>Zaznacz kolumnę</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="187"/>
+        <location filename="../gui/configuration_dialog.cpp" line="188"/>
         <source>Select pattern</source>
         <translation>Wybierz wzorzec</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="188"/>
+        <location filename="../gui/configuration_dialog.cpp" line="189"/>
         <source>Select order</source>
         <translation>Wybierz klatkę</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="189"/>
+        <location filename="../gui/configuration_dialog.cpp" line="190"/>
         <source>Go to step</source>
         <translation>Idź do kroku</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="190"/>
+        <location filename="../gui/configuration_dialog.cpp" line="191"/>
         <source>Toggle track</source>
         <translation>Włącz kanał</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="191"/>
+        <location filename="../gui/configuration_dialog.cpp" line="192"/>
         <source>Solo track</source>
         <translation>Wyizoluj kanał</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="192"/>
+        <location filename="../gui/configuration_dialog.cpp" line="193"/>
         <source>Interpolate</source>
         <translation>Dodaj</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="193"/>
+        <location filename="../gui/configuration_dialog.cpp" line="194"/>
         <source>Reverse</source>
         <translation>Odwróć</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="194"/>
+        <location filename="../gui/configuration_dialog.cpp" line="195"/>
         <source>Go to previous order</source>
         <translation>Przejdź do poprzedniego klatki</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="195"/>
+        <location filename="../gui/configuration_dialog.cpp" line="196"/>
         <source>Go to next order</source>
         <translation>Przejdź do następnej klatki</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="196"/>
+        <location filename="../gui/configuration_dialog.cpp" line="197"/>
         <source>Toggle bookmark</source>
         <translation>Włącz zakładkę</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="197"/>
+        <location filename="../gui/configuration_dialog.cpp" line="198"/>
         <source>Previous bookmark</source>
         <translation>Poprzednia zakładka</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="198"/>
+        <location filename="../gui/configuration_dialog.cpp" line="199"/>
         <source>Next bookmark</source>
         <translation>Następna zakładka</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="199"/>
+        <location filename="../gui/configuration_dialog.cpp" line="200"/>
         <source>Transpose, decrease note</source>
         <translation>Transponuj, zwiększ nutę</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="200"/>
+        <location filename="../gui/configuration_dialog.cpp" line="201"/>
         <source>Transpose, increase note</source>
         <translation>Transponuj, zwiększ nutę</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="201"/>
+        <location filename="../gui/configuration_dialog.cpp" line="202"/>
         <source>Transpose, decrease octave</source>
         <translation>Transponuj, zmniejsz oktawę</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="202"/>
+        <location filename="../gui/configuration_dialog.cpp" line="203"/>
         <source>Transpose, increase octave</source>
         <translation>Transponuj, zwiększ oktawę</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="203"/>
+        <location filename="../gui/configuration_dialog.cpp" line="204"/>
         <source>Previous instrument</source>
         <translation>Poprzedni instrument</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="204"/>
+        <location filename="../gui/configuration_dialog.cpp" line="205"/>
         <source>Next instrument</source>
         <translation>Następny instrument</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="205"/>
+        <location filename="../gui/configuration_dialog.cpp" line="206"/>
         <source>Mask instrument</source>
         <translation>Maska instrumentu</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="206"/>
+        <location filename="../gui/configuration_dialog.cpp" line="207"/>
         <source>Mask volume</source>
         <translation>Maska poziomu głośności</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="207"/>
+        <location filename="../gui/configuration_dialog.cpp" line="208"/>
         <source>Edit instrument</source>
         <translation>Edytuj instrument</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="208"/>
+        <location filename="../gui/configuration_dialog.cpp" line="209"/>
         <source>Follow mode</source>
         <translation>Tryb podążania</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="209"/>
+        <location filename="../gui/configuration_dialog.cpp" line="210"/>
         <source>Duplicate order</source>
         <translation>Duplikuj wzorzec</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="210"/>
+        <location filename="../gui/configuration_dialog.cpp" line="211"/>
         <source>Clone patterns</source>
         <translation>Klonuj wzorce</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="211"/>
+        <location filename="../gui/configuration_dialog.cpp" line="212"/>
         <source>Clone order</source>
         <translation>Klonuj klatkę</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="212"/>
+        <location filename="../gui/configuration_dialog.cpp" line="213"/>
         <source>Replace instrument</source>
         <translation>Zastąp instrument</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="213"/>
+        <location filename="../gui/configuration_dialog.cpp" line="214"/>
         <source>Expand pattern</source>
         <translation>Rozszerz wzorzec</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="214"/>
+        <location filename="../gui/configuration_dialog.cpp" line="215"/>
         <source>Shrink pattern</source>
         <translation>Zwiń wzorzec</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="215"/>
+        <location filename="../gui/configuration_dialog.cpp" line="216"/>
         <source>Fine decrease values</source>
         <translation>Zmniejsz wartość o 1</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="216"/>
+        <location filename="../gui/configuration_dialog.cpp" line="217"/>
         <source>Fine increase values</source>
         <translation>Zwiększ wartość o 1</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="217"/>
+        <location filename="../gui/configuration_dialog.cpp" line="218"/>
         <source>Coarse decrease values</source>
         <translation>Zmniejsz wartość o 16</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="218"/>
+        <location filename="../gui/configuration_dialog.cpp" line="219"/>
         <source>Coarse increase valuse</source>
         <translation>Zmniejsz wartość o 16</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="219"/>
+        <location filename="../gui/configuration_dialog.cpp" line="220"/>
         <source>Expand effect column</source>
         <translation>Rozszerz kolumnę efektów</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="220"/>
+        <location filename="../gui/configuration_dialog.cpp" line="221"/>
         <source>Shrink effect column</source>
         <translation>Zwiń kolumnę efektów</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="221"/>
+        <location filename="../gui/configuration_dialog.cpp" line="222"/>
         <source>Previous highlighted step</source>
         <translation>Poprzedni podświetlny krok</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="222"/>
+        <location filename="../gui/configuration_dialog.cpp" line="223"/>
         <source>Next highlighted step</source>
         <translation>Następny podświetlony krok</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="223"/>
+        <location filename="../gui/configuration_dialog.cpp" line="224"/>
         <source>Increase pattern size</source>
         <translation>Zwiększ rozmiar wzorca</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="224"/>
+        <location filename="../gui/configuration_dialog.cpp" line="225"/>
         <source>Decrease pattern size</source>
         <translation>Zmniejsz rozmiar wzorca</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="225"/>
+        <location filename="../gui/configuration_dialog.cpp" line="226"/>
         <source>Increase edit step</source>
         <translation>Zwiększ krok podczas edycji</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="226"/>
+        <location filename="../gui/configuration_dialog.cpp" line="227"/>
         <source>Decrease edit step</source>
         <translation>Zmniejsz krok podczas edycji</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="227"/>
+        <location filename="../gui/configuration_dialog.cpp" line="228"/>
         <source>Display effect list</source>
         <translation>Wyświetl listę efektów</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="228"/>
+        <location filename="../gui/configuration_dialog.cpp" line="229"/>
         <source>Previous song</source>
         <translation>Poprzednia piosenka</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="229"/>
+        <location filename="../gui/configuration_dialog.cpp" line="230"/>
         <source>Next song</source>
         <translation>Następna piosenka</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="230"/>
+        <location filename="../gui/configuration_dialog.cpp" line="231"/>
         <source>Jam volume up</source>
         <translation>Podnieś głośność przy improwizacji</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="231"/>
+        <location filename="../gui/configuration_dialog.cpp" line="232"/>
         <source>Jam volume down</source>
         <translation>Obniż głośność przy improwizacji</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="314"/>
+        <location filename="../gui/configuration_dialog.cpp" line="315"/>
         <source>None</source>
         <translation>Żaden</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="510"/>
+        <location filename="../gui/configuration_dialog.cpp" line="511"/>
         <source>Description: %1</source>
         <translation>Opis: %1</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="604"/>
+        <location filename="../gui/configuration_dialog.cpp" line="605"/>
         <source>Set %1</source>
         <translation>Zestaw %1</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="746"/>
+        <location filename="../gui/configuration_dialog.cpp" line="747"/>
         <source>Open color scheme</source>
         <translation>Otwórz układ kolorów</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="748"/>
-        <location filename="../gui/configuration_dialog.cpp" line="768"/>
+        <location filename="../gui/configuration_dialog.cpp" line="749"/>
+        <location filename="../gui/configuration_dialog.cpp" line="769"/>
         <source>ini file (*.ini)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="748"/>
-        <location filename="../gui/configuration_dialog.cpp" line="768"/>
+        <location filename="../gui/configuration_dialog.cpp" line="749"/>
+        <location filename="../gui/configuration_dialog.cpp" line="769"/>
         <source>All files (*)</source>
         <translation>Wszystkie pliki (*)</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="760"/>
-        <location filename="../gui/configuration_dialog.cpp" line="779"/>
+        <location filename="../gui/configuration_dialog.cpp" line="761"/>
+        <location filename="../gui/configuration_dialog.cpp" line="780"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="760"/>
+        <location filename="../gui/configuration_dialog.cpp" line="761"/>
         <source>An unknown error occurred while loading the color scheme.</source>
         <translation>Wystąpił nieoczekiwany błąd podczas ładowania układu kolorów.</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="766"/>
+        <location filename="../gui/configuration_dialog.cpp" line="767"/>
         <source>Save color scheme</source>
         <translation>Zapisz układ kolorów</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="779"/>
+        <location filename="../gui/configuration_dialog.cpp" line="780"/>
         <source>Failed to save the color scheme.</source>
         <translation>Nie udało się zapisać układu kolorów.</translation>
     </message>
@@ -1371,123 +1371,123 @@
 <context>
     <name>EffectDescription</name>
     <message>
-        <location filename="../gui/effect_description.cpp" line="43"/>
+        <location filename="../gui/effect_description.cpp" line="42"/>
         <source>Arpeggio, x: 2nd note (0-F), y: 3rd note (0-F)</source>
         <translation>Arpeggio, x: druga nuta(0-F), y: trzecia nuta(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="44"/>
+        <location filename="../gui/effect_description.cpp" line="43"/>
         <source>Portamento up, xx: depth (00-FF)</source>
         <translation>Portamento w górę, xx: głębokość(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="45"/>
+        <location filename="../gui/effect_description.cpp" line="44"/>
         <source>Portamento down, xx: depth (00-FF)</source>
         <translation>Portamento w dół, xx: głębokość(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="46"/>
+        <location filename="../gui/effect_description.cpp" line="45"/>
         <source>Tone portamento, xx: depth (00-FF)</source>
         <translation>Portamento tonu, xx: głębokość(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="47"/>
+        <location filename="../gui/effect_description.cpp" line="46"/>
         <source>Vibrato, x: period (0-F), y: depth (0-F)</source>
         <translation>Vibrato, x: okres(0-F), y: głębokość(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="48"/>
+        <location filename="../gui/effect_description.cpp" line="47"/>
         <source>Tremolo, x: period (0-F), y: depth (0-F)</source>
         <translation>Tremolo, x: okres(0-F), y: głębokość(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="49"/>
+        <location filename="../gui/effect_description.cpp" line="48"/>
         <source>Pan, xx: 00 = no sound, 01 = right, 02 = left, 03 = center</source>
         <translation>Ustawienie stereo, xx: 00 = cisza, 01 = prawo, 02 = lewo, 03 = środek</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="50"/>
+        <location filename="../gui/effect_description.cpp" line="49"/>
         <source>Volume slide, x: up (0-F), y: down (0-F)</source>
         <translation>Zjazd poziomu głośności, x: w górę(0-F), y: w dół(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="51"/>
+        <location filename="../gui/effect_description.cpp" line="50"/>
         <source>Jump to beginning of order xx</source>
         <translation>Przeskocz do początku klatki xx</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="52"/>
+        <location filename="../gui/effect_description.cpp" line="51"/>
         <source>End of song</source>
         <translation>Koniec piosenki</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="53"/>
+        <location filename="../gui/effect_description.cpp" line="52"/>
         <source>Jump to step xx of next order</source>
         <translation>Przeskocz do kroku xx następnego klatki</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="54"/>
+        <location filename="../gui/effect_description.cpp" line="53"/>
         <source>Change speed (xx: 00-1F), change tempo (xx: 20-FF)</source>
         <translation>Zmień szybkość (xx: 00-1F), zmień tempo (xx: 20-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="55"/>
+        <location filename="../gui/effect_description.cpp" line="54"/>
         <source>Note delay, xx: count (00-FF)</source>
         <translation>Opóźnienie nuty, xx: ilość(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="56"/>
+        <location filename="../gui/effect_description.cpp" line="55"/>
         <source>Auto envelope, x: shift amount (0-F), y: shape (0-F)</source>
         <translation>Automatyczna obwiednia, x: przesunięcie(x-8), y: kształt(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="57"/>
+        <location filename="../gui/effect_description.cpp" line="56"/>
         <source>Hardware envelope period 1, xx: high byte (00-FF)</source>
         <translation>Okres wykonania sprzętowej obwiedni 1, xx: wysoki bajt(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="58"/>
+        <location filename="../gui/effect_description.cpp" line="57"/>
         <source>Hardware envelope period 2, xx: low byte (00-FF)</source>
         <translation>Okres wykonania sprzętowej obiedni 2, xx: niski bajt(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="59"/>
+        <location filename="../gui/effect_description.cpp" line="58"/>
         <source>Retrigger, x: volume slide (0-7: up, 8-F: down), y: tick (1-F)</source>
         <translatorcomment>i don&apos;t have bloody idea how to translate that, I&apos;m sorry</translatorcomment>
         <translation>Wyzwól ponownie, x: zjazd poziomu głośności (0-7: w górę, 8-F: w dół), y: tick (1-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="60"/>
+        <location filename="../gui/effect_description.cpp" line="59"/>
         <source>Set groove xx</source>
         <translation>Ustaw Groove o wartości xx</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="61"/>
+        <location filename="../gui/effect_description.cpp" line="60"/>
         <source>Detune, xx: pitch (00-FF)</source>
         <translation>Rozstrój, xx: wysokość w centach(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="62"/>
+        <location filename="../gui/effect_description.cpp" line="61"/>
         <source>Note slide up, x: count (0-F), y: seminote (0-F)</source>
         <translation>Zjazd nuty w górę, x: ilość(0-F), y: półton(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="63"/>
+        <location filename="../gui/effect_description.cpp" line="62"/>
         <source>Note slide down, x: count (0-F), y: seminote (0-F)</source>
         <translation>Zjazd nuty w dół, x: ilość(0-F), y: półton(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="64"/>
+        <location filename="../gui/effect_description.cpp" line="63"/>
         <source>Note cut, xx: count (00-FF)</source>
         <translation>Odcięcie nuty, xx: ilość(00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="65"/>
+        <location filename="../gui/effect_description.cpp" line="64"/>
         <source>Transpose delay, x: count (0-7: up, 8-F: down), y: seminote (0-F)</source>
         <translation>Opóźnienie transponowania, x: ilość(0-7: góra, 8-F: dół), y: pólton(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="79"/>
+        <location filename="../gui/effect_description.cpp" line="78"/>
         <source>Volume delay, x: count (0-F), yy: volume (00-FF)</source>
         <translation>Opóżnienie głośności, x: ilość(0-F), yy: głośność (00-FF)</translation>
     </message>
@@ -1500,67 +1500,67 @@
         <translation type="vanished">Opóźnienie transponowania, x: ilość(1-7: góra, 9-F: dół), y: pólton(0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="66"/>
+        <location filename="../gui/effect_description.cpp" line="65"/>
         <source>Tone/Noise mix, xx: 00 = no sound, 01 = tone, 02 = noise, 03 = tone &amp; noise</source>
         <translation>Mikser tonu/szumu, xx: 00=cisza, 01=ton, 02=szum, 03=ton &amp; szum</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="67"/>
+        <location filename="../gui/effect_description.cpp" line="66"/>
         <source>Master volume, xx: volume (00-3F)</source>
         <translation>Główny poziom głośności, xx: głośność (00-3F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="68"/>
+        <location filename="../gui/effect_description.cpp" line="67"/>
         <source>Noise pitch, xx: pitch (00-1F)</source>
         <translation>Częstotliwość szumu, xx: wysokość (00-1F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="69"/>
+        <location filename="../gui/effect_description.cpp" line="68"/>
         <source>Register address bank 0, xx: address (00-6B)</source>
         <translation>Bank adresów rejestru 0, xx: adres (00-B6)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="70"/>
+        <location filename="../gui/effect_description.cpp" line="69"/>
         <source>Register address bank 1, xx: address (00-6B)</source>
         <translation>Bank adresów rejestru 1, xx: adres (00-B6)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="71"/>
+        <location filename="../gui/effect_description.cpp" line="70"/>
         <source>Register value set, xx: value (00-FF)</source>
         <translation>Ustaw wartości rejestrów,  xx: wartość rejestru (00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="72"/>
+        <location filename="../gui/effect_description.cpp" line="71"/>
         <source>AR control, x: operator (1-4), yy: attack rate (00-1F)</source>
         <translation>Kotrola AR, x: operator(1-4), yy: wartość AR (00-1F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="73"/>
+        <location filename="../gui/effect_description.cpp" line="72"/>
         <source>Brightness, xx: relative value (01-FF)</source>
         <translation>Brightness, xx: wartość względna (01-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="74"/>
+        <location filename="../gui/effect_description.cpp" line="73"/>
         <source>DR control, x: operator (1-4), yy: decay rate (00-1F)</source>
         <translation>Kontrola DR, x: operator(1-4), yy: wartość DR (00-1F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="75"/>
+        <location filename="../gui/effect_description.cpp" line="74"/>
         <source>Envelope reset, xx: count (00-FF)</source>
         <translation>Resetuj obwiednię, xx: ilość (00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="76"/>
+        <location filename="../gui/effect_description.cpp" line="75"/>
         <source>FB control, xx: feedback value (00-07)</source>
         <translation>Kontrola FB, xx: ilość sygnału zwrotnego (00-07)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="77"/>
+        <location filename="../gui/effect_description.cpp" line="76"/>
         <source>Fine detune, xx: pitch (00-FF)</source>
         <translation>Rozstrojenie, xx: wysokość (00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="78"/>
+        <location filename="../gui/effect_description.cpp" line="77"/>
         <source>ML control, x: operator (1-4), y: multiple (0-F)</source>
         <translation>Kontrola ML, x: operator(1-4), y: wartość ML (0-F)</translation>
     </message>
@@ -1569,17 +1569,17 @@
         <translation type="vanished">Opóżnienie głośności, x: ilość(1-F), yy: głośność (00-FF)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="80"/>
+        <location filename="../gui/effect_description.cpp" line="79"/>
         <source>RR control, x: operator (1-4), y: release rate (0-F)</source>
         <translation>Kontrola RR, x: operator(1-4), y: wartość RR (0-F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="81"/>
+        <location filename="../gui/effect_description.cpp" line="80"/>
         <source>TL control, x: operator (1-4), yy: total level (00-7F)</source>
         <translation>Kontrola TL, x: operator(1-4), yy: wartość TL (00-7F)</translation>
     </message>
     <message>
-        <location filename="../gui/effect_description.cpp" line="82"/>
+        <location filename="../gui/effect_description.cpp" line="81"/>
         <source>Invalid effect</source>
         <translation>Nieprawidłowy efekt</translation>
     </message>
@@ -1720,42 +1720,42 @@
         <translation type="vanished">instrument</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="54"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="55"/>
         <source>Path does not exist.</source>
         <translation>Ścieżka do podanego pliku nie istnieje.</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="57"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="58"/>
         <source>Unsupported file format.</source>
         <translation>Niewspierany format pliku.</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="60"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="61"/>
         <source>Could not load the %1 properly. Please make sure that you have the latest version of BambooTracker.</source>
         <translation>Nie udało się wczytać %1. Upewnij się że masz najnowszą wersję Bamboo Trackera.</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="64"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="65"/>
         <source>Could not load the %1. It may be corrupted. Stopped at %2.</source>
         <translation>Nie udało się wczytać %1. Najprawdopodobniej jest uszkodzony. Zatrzymano na: %2。</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="73"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="74"/>
         <source>Failed to load %1.</source>
         <translation>Nie udało sie wczytać %1.</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="80"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="81"/>
         <source>Failed to export to %1.</source>
         <translation>Nie udało się wyeksportować %1.</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="83"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="84"/>
         <source>Failed to save the %1.</source>
         <translation>Nie udało się zapisać %1.</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="92"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="93"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
@@ -1768,32 +1768,32 @@
 <context>
     <name>FileType</name>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="32"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="33"/>
         <source>module</source>
         <translation type="unfinished">moduł</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="33"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="34"/>
         <source>s98</source>
         <translation type="unfinished">S98</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="34"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="35"/>
         <source>vgm</source>
         <translation type="unfinished">VGM</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="35"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="36"/>
         <source>wav</source>
         <translation type="unfinished">WAV</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="36"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="37"/>
         <source>bank</source>
         <translation type="unfinished">bank brzmień</translation>
     </message>
     <message>
-        <location filename="../gui/file_io_error_message_box.cpp" line="37"/>
+        <location filename="../gui/file_io_error_message_box.cpp" line="38"/>
         <source>instrument</source>
         <translation type="unfinished">instrument</translation>
     </message>
@@ -2451,16 +2451,16 @@
         <translation>Tempo</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2066"/>
-        <location filename="../gui/mainwindow.cpp" line="2521"/>
-        <location filename="../gui/mainwindow.cpp" line="2523"/>
-        <location filename="../gui/mainwindow.cpp" line="2549"/>
+        <location filename="../gui/mainwindow.cpp" line="2061"/>
+        <location filename="../gui/mainwindow.cpp" line="2516"/>
+        <location filename="../gui/mainwindow.cpp" line="2518"/>
+        <location filename="../gui/mainwindow.cpp" line="2544"/>
         <source>Untitled</source>
         <translation>Bez nazwy</translation>
     </message>
     <message>
         <location filename="../gui/mainwindow.ui" line="244"/>
-        <location filename="../gui/mainwindow.cpp" line="3693"/>
+        <location filename="../gui/mainwindow.cpp" line="3688"/>
         <source>Groove</source>
         <translation>Groove</translation>
     </message>
@@ -3296,14 +3296,14 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="267"/>
+        <location filename="../gui/mainwindow.cpp" line="262"/>
         <source>Octave</source>
         <translation>Oktawa</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="280"/>
-        <location filename="../gui/mainwindow.cpp" line="541"/>
-        <location filename="../gui/mainwindow.cpp" line="2331"/>
+        <location filename="../gui/mainwindow.cpp" line="275"/>
+        <location filename="../gui/mainwindow.cpp" line="536"/>
+        <location filename="../gui/mainwindow.cpp" line="2326"/>
         <source>Octave: %1</source>
         <oldsource>Octave: </oldsource>
         <translation>Oktawa: %1</translation>
@@ -3314,210 +3314,210 @@
         <translation type="vanished">Zapisać zmiany do %1?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2509"/>
-        <location filename="../gui/mainwindow.hpp" line="234"/>
-        <location filename="../gui/mainwindow.hpp" line="250"/>
+        <location filename="../gui/mainwindow.cpp" line="2504"/>
+        <location filename="../gui/mainwindow.hpp" line="243"/>
+        <location filename="../gui/mainwindow.hpp" line="259"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1353"/>
-        <location filename="../gui/mainwindow.cpp" line="1374"/>
+        <location filename="../gui/mainwindow.cpp" line="1348"/>
+        <location filename="../gui/mainwindow.cpp" line="1369"/>
         <source>Instrument %1</source>
         <oldsource>Instrument </oldsource>
         <translation>Instrument %1</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="543"/>
+        <location filename="../gui/mainwindow.cpp" line="538"/>
         <source>Welcome to BambooTracker v%1!</source>
         <translation>Witamy w programie BambooTracker v%1!</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1705"/>
+        <location filename="../gui/mainwindow.cpp" line="1700"/>
         <source>Open instrument</source>
         <translation>Otwórz instrument</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1769"/>
+        <location filename="../gui/mainwindow.cpp" line="1764"/>
         <source>Save instrument</source>
         <translation>Zapisz instrument</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1815"/>
+        <location filename="../gui/mainwindow.cpp" line="1810"/>
         <source>Open bank</source>
         <translation>Otwórz bank brzmień</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1879"/>
+        <location filename="../gui/mainwindow.cpp" line="1874"/>
         <source>Select instruments to load:</source>
         <translation>Wybierz instrument:</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2538"/>
-        <location filename="../gui/mainwindow.cpp" line="2588"/>
+        <location filename="../gui/mainwindow.cpp" line="2533"/>
+        <location filename="../gui/mainwindow.cpp" line="2583"/>
         <source>No instrument</source>
         <translation>Brak instrumentów</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2228"/>
+        <location filename="../gui/mainwindow.cpp" line="2223"/>
         <source>Standard</source>
         <translation>Standartowy</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="174"/>
+        <location filename="../gui/mainwindow.cpp" line="169"/>
         <source>English</source>
         <comment>Default notation system</comment>
         <extracomment>Set the name of suitable notation system (English or German)</extracomment>
         <translation>Angielski</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="283"/>
+        <location filename="../gui/mainwindow.cpp" line="278"/>
         <source>Volume</source>
         <translation>Poziom głośności</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="300"/>
+        <location filename="../gui/mainwindow.cpp" line="295"/>
         <source>Step highlight 1st</source>
         <translation>Pierwsze podkreślenie kroku</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="316"/>
+        <location filename="../gui/mainwindow.cpp" line="311"/>
         <source>2nd</source>
         <translation>Drugie</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="683"/>
+        <location filename="../gui/mainwindow.cpp" line="678"/>
         <source>Welcome to BambooTracker!</source>
         <translation>Witamy w programie BambooTracker!</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="687"/>
+        <location filename="../gui/mainwindow.cpp" line="682"/>
         <source>Don&apos;t know where to start?</source>
         <translation>Nie wiesz gdzie zacząć?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="688"/>
+        <location filename="../gui/mainwindow.cpp" line="683"/>
         <source>Check the demo modules and instruments included with your download of BambooTracker.</source>
         <translation>Sprawdź piosenki demonstracyjne i instrumenty dołączone do twojej kopii BambooTrackera.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="690"/>
+        <location filename="../gui/mainwindow.cpp" line="685"/>
         <source>Need a list of effects and shortcuts?</source>
         <translation>Potrzebujesz listy efektów i skrótów klawiszowych?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="691"/>
+        <location filename="../gui/mainwindow.cpp" line="686"/>
         <source>Check the Help menu at the top of the window.</source>
         <translation>Sprawdź menu pomocy w górnej części okna.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="692"/>
+        <location filename="../gui/mainwindow.cpp" line="687"/>
         <source>Still lost?</source>
         <translation>Wciąż zagubiony?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="693"/>
+        <location filename="../gui/mainwindow.cpp" line="688"/>
         <source>The README.md has a link to our Discord server.</source>
         <translation>Plik README.md zawiera link do naszego serwera na Discordzie.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="694"/>
+        <location filename="../gui/mainwindow.cpp" line="689"/>
         <source>Think you&apos;ve found a bug? Missing a feature?</source>
         <translation>Uważasz że znalazłeś błąd w programie? Brakującą funkcję?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="695"/>
+        <location filename="../gui/mainwindow.cpp" line="690"/>
         <source>BambooTracker is still in development, bugs and missing features are to be expected. So we need your help!</source>
         <translation>BambooTracker jest wciąż w fazie rozwoju, należy się spodziewać błedów i brakujących funkcji. Potrzebujemy więc Twojej pomocy!</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="699"/>
+        <location filename="../gui/mainwindow.cpp" line="694"/>
         <source>Please report any bugs you find and requests and features you&apos;d like to see on our Discord server or our bug tracker (%1).</source>
         <translation>Prosimy o zgłaszanie jakichkolwiek błedów i próśb o nowe funkcje na nasz serwer na Discordzie lub na naszego bugtrackera (%1).</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="703"/>
+        <location filename="../gui/mainwindow.cpp" line="698"/>
         <source>If you&apos;re a developer yourself or would like to start being one, consider contributing to the project yourself. Any help would be appreciated!</source>
         <translation>Jeżeli jestes programistą, albo chcesz nim zostać, rozważ proszę wsparcie tego projektu. Każda pomoc jest doceniana!</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="707"/>
+        <location filename="../gui/mainwindow.cpp" line="702"/>
         <source>Welcome</source>
         <translation>Witamy</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1724"/>
-        <location filename="../gui/mainwindow.cpp" line="1936"/>
+        <location filename="../gui/mainwindow.cpp" line="1719"/>
+        <location filename="../gui/mainwindow.cpp" line="1931"/>
         <source>The number of instruments has reached the upper limit.</source>
         <translation>Ilość instrumentów przekroczyła wartość maksymalną.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1968"/>
+        <location filename="../gui/mainwindow.cpp" line="1963"/>
         <source>Select instruments to save:</source>
         <translation>Wybierz instrument do zapisu:</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="1979"/>
+        <location filename="../gui/mainwindow.cpp" line="1974"/>
         <source>Save bank</source>
         <translation>Zapisz bank brzmień</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2095"/>
+        <location filename="../gui/mainwindow.cpp" line="2090"/>
         <source>-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2100"/>
+        <location filename="../gui/mainwindow.cpp" line="2095"/>
         <source>Custom</source>
         <translation>Niestandartowy</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2105"/>
+        <location filename="../gui/mainwindow.cpp" line="2100"/>
         <source>PC-9821 with PC-9801-86</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2110"/>
+        <location filename="../gui/mainwindow.cpp" line="2105"/>
         <source>PC-9821 with Speak Board</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2115"/>
+        <location filename="../gui/mainwindow.cpp" line="2110"/>
         <source>PC-88VA2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2120"/>
+        <location filename="../gui/mainwindow.cpp" line="2115"/>
         <source>NEC PC-8801mkIISR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2229"/>
+        <location filename="../gui/mainwindow.cpp" line="2224"/>
         <source>FM3ch expanded</source>
         <translation>Roszszerzenie FM3ch</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2258"/>
+        <location filename="../gui/mainwindow.cpp" line="2253"/>
         <source>Insufficient memory size to load ADPCM samples. Please delete the unused samples.</source>
         <translation>Niewystarczająca ilość pamięci, by wczytać próbki ADPCM. Proszę usunąć nieużywane próbki.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2409"/>
+        <location filename="../gui/mainwindow.cpp" line="2404"/>
         <source>The module has been changed. Do you want to save it?</source>
         <translation>Moduł został zmieniony. Czy chcesz go zapisać?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2984"/>
+        <location filename="../gui/mainwindow.cpp" line="2979"/>
         <source>This software is licensed under the GNU General Public License v2.0 or later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2999"/>
+        <location filename="../gui/mainwindow.cpp" line="2994"/>
         <source>Nuked OPN-MOD by (C) Alexey Khokholov (Nuke.YKT), Jean Pierre Cimalando (LGPL v2.1+)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3007"/>
+        <location filename="../gui/mainwindow.cpp" line="3002"/>
         <source>ymdeltat by (C) Tatsuyuki Satoh, Jarek Burczynski, ValleyBell (GPL v2+)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3530,98 +3530,98 @@
         <translation type="vanished">&lt;b&gt;YM2608 Music Tracker&lt;br&gt;Copyright (C) 2018-2021 Rerrah&lt;/b&gt;&lt;br&gt;&lt;hr&gt;Biblioteki:&lt;br&gt;- C86CTL by (C) honet (BSD 3-Clause)&lt;br&gt;- libOPNMIDI by (C) Vitaly Novichkov (część na licencji MIT)&lt;br&gt;- MAME (MAME License)&lt;br&gt;- Nuked OPN-MOD by (C) Alexey Khokholov (Nuke.YKT)&lt;br&gt;i (C) Jean Pierre Cimalando (LGPL v2.1)&lt;br&gt;- RtAudio by (C) Gary P. Scavone (RtAudio License)&lt;br&gt;- RtMidi by (C) Gary P. Scavone (RtMidi License)&lt;br&gt;- SCCI by (C) gasshi (SCCI License)&lt;br&gt;- Silk icons by (C) Mark James (CC BY 2.5 or 3.0)&lt;br&gt;- Qt (GPL v2+ lub LGPL v3)&lt;br&gt;- VGMPlay by (C) Valley Bell (GPL v2)&lt;br&gt;&lt;br&gt;Zobacz również changelog, która wymienia współautorów.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.hpp" line="251"/>
+        <location filename="../gui/mainwindow.hpp" line="260"/>
         <source>Could not initialize MIDI input.</source>
         <translation>Nie udało się uruchomić wejścia MIDI.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3196"/>
-        <location filename="../gui/mainwindow.cpp" line="3262"/>
+        <location filename="../gui/mainwindow.cpp" line="3191"/>
+        <location filename="../gui/mainwindow.cpp" line="3257"/>
         <source>BambooTracker module (*.btm)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3196"/>
-        <location filename="../gui/mainwindow.cpp" line="3262"/>
-        <location filename="../gui/mainwindow.cpp" line="3383"/>
-        <location filename="../gui/mainwindow.cpp" line="3518"/>
-        <location filename="../gui/mainwindow.cpp" line="3586"/>
+        <location filename="../gui/mainwindow.cpp" line="3191"/>
+        <location filename="../gui/mainwindow.cpp" line="3257"/>
+        <location filename="../gui/mainwindow.cpp" line="3378"/>
+        <location filename="../gui/mainwindow.cpp" line="3513"/>
+        <location filename="../gui/mainwindow.cpp" line="3581"/>
         <source>All files (*)</source>
         <translation>Wszystkie pliki (*)</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3383"/>
+        <location filename="../gui/mainwindow.cpp" line="3378"/>
         <source>WAV signed 16-bit PCM (*.wav)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3421"/>
+        <location filename="../gui/mainwindow.cpp" line="3416"/>
         <source>Export %1 to WAV</source>
         <translation>Eksportuj %1 do WAV</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3518"/>
+        <location filename="../gui/mainwindow.cpp" line="3513"/>
         <source>VGM file (*.vgm)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3586"/>
+        <location filename="../gui/mainwindow.cpp" line="3581"/>
         <source>S98 file (*.s98)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3753"/>
+        <location filename="../gui/mainwindow.cpp" line="3748"/>
         <source>Do you want to remove all duplicate instruments?</source>
         <translation>Czy chcesz usunąć wszystkie zduplikowane instrumenty?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3856"/>
+        <location filename="../gui/mainwindow.cpp" line="3851"/>
         <source>Do you want to remove all unused ADPCM samples?</source>
         <translation>Czy chcesz usunąć wszystkie nieużywane próbki ADPCM?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3899"/>
+        <location filename="../gui/mainwindow.cpp" line="3894"/>
         <source>Do you want to transpose a song?</source>
         <translation>Czy chcesz transponować piosenkę?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3920"/>
+        <location filename="../gui/mainwindow.cpp" line="3915"/>
         <source>Do you want to swap tracks?</source>
         <translation>Czy chcesz zamienić kanały?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3974"/>
+        <location filename="../gui/mainwindow.cpp" line="3969"/>
         <source>Approximate song length: %1m%2s</source>
         <translation>Przybliżona długość piosenki: %1m%2s</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2590"/>
+        <location filename="../gui/mainwindow.cpp" line="2585"/>
         <source>Instrument: %1</source>
         <oldsource>Instrument: </oldsource>
         <translation>Instrument: %1</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2881"/>
+        <location filename="../gui/mainwindow.cpp" line="2876"/>
         <source>Do you want to change song properties?</source>
         <translation>Czy chcesz zmienić właściwości piosenki?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2957"/>
+        <location filename="../gui/mainwindow.cpp" line="2952"/>
         <source>Change to jam mode</source>
         <translation>Wejdź w tryb improwizacji</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2957"/>
+        <location filename="../gui/mainwindow.cpp" line="2952"/>
         <source>Change to edit mode</source>
         <translation>Wejdź w tryb edycji</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2979"/>
+        <location filename="../gui/mainwindow.cpp" line="2974"/>
         <source>YM2608 Music Tracker</source>
         <translation>Tracker muzyczny dla YM2608</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2981"/>
+        <location filename="../gui/mainwindow.cpp" line="2976"/>
         <source>Web:</source>
         <translation>Strona:</translation>
     </message>
@@ -3630,42 +3630,42 @@
         <translation type="vanished">To oprogramowanie jest objęte licencją GNU General Public Licence v2.0.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2985"/>
+        <location filename="../gui/mainwindow.cpp" line="2980"/>
         <source>Source is available at:</source>
         <translation>Kod źródłowy jest dostępny na:</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2988"/>
+        <location filename="../gui/mainwindow.cpp" line="2983"/>
         <source>Libraries:</source>
         <translation>Biblioteki:</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2989"/>
+        <location filename="../gui/mainwindow.cpp" line="2984"/>
         <source>Also see changelog which lists contributors.</source>
         <translation>Zobacz także changelog wymieniający współautorów.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2990"/>
+        <location filename="../gui/mainwindow.cpp" line="2985"/>
         <source>Thank you to everyone who reports bugs, makes suggestions, and contributes to this project!</source>
         <translation>Dziękujemy każdemu kto zgłasza błedy, sugeruje zmiany i wspomaga ten projekt!</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2994"/>
+        <location filename="../gui/mainwindow.cpp" line="2989"/>
         <source>C86CTL by (C) honet (BSD 3-Clause)</source>
         <translation>C86CTL autorstwa (C) honet (3-klauzulowa licencja BSD)</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2996"/>
+        <location filename="../gui/mainwindow.cpp" line="2991"/>
         <source>emu2149 by (C) Mitsutaka Okazaki (MIT License)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2997"/>
+        <location filename="../gui/mainwindow.cpp" line="2992"/>
         <source>fmopn by (C) Tatsuyuki Satoh, Jarek Burczynski, ValleyBell (GPL v2+)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2998"/>
+        <location filename="../gui/mainwindow.cpp" line="2993"/>
         <source>libOPNMIDI by (C) Vitaly Novichkov (MIT License part)</source>
         <translation>libOPNMIDI autorstwa (C) Vitaly Novichkov (część objęta licencją MIT)</translation>
     </message>
@@ -3678,27 +3678,27 @@
         <translation type="vanished">Nuked OPN-MOD autorstwa (C) Alexey Khokholov (Nuke.YKT), Jean Pierre Cimalando (LGPL v2.1)</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3001"/>
+        <location filename="../gui/mainwindow.cpp" line="2996"/>
         <source>RtAudio by (C) Gary P. Scavone (RtAudio License)</source>
         <translation>RtAudio autorstwa (C) Gary P. Scavone (Licencja RtAudio)</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3002"/>
+        <location filename="../gui/mainwindow.cpp" line="2997"/>
         <source>RtMidi by (C) Gary P. Scavone (RtMidi License)</source>
         <translation>RtMidi autorstwa (C) Gary P. Scavone (Licencja RtMidi)</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3004"/>
+        <location filename="../gui/mainwindow.cpp" line="2999"/>
         <source>SCCI by (C) gasshi (SCCI License)</source>
         <translation>SCCI autorstwa (C) gasshi (Licencja SCCI)</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3006"/>
+        <location filename="../gui/mainwindow.cpp" line="3001"/>
         <source>Silk icons by (C) Mark James (CC BY 2.5 or 3.0)</source>
         <translation>Ikony Silk autorstwa (C) Mark James (CC BY 2.5 lub 3.0)</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3000"/>
+        <location filename="../gui/mainwindow.cpp" line="2995"/>
         <source>Qt (GPL v2+ or LGPL v3)</source>
         <translation>Qt (GPL v2+ lub LGPL v3)</translation>
     </message>
@@ -3707,12 +3707,12 @@
         <translation type="vanished">VGMPlay autorstwa (C) Valley Bell (GPL v2)</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3024"/>
+        <location filename="../gui/mainwindow.cpp" line="3019"/>
         <source>About</source>
         <translation>O programie</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2509"/>
+        <location filename="../gui/mainwindow.cpp" line="2504"/>
         <source>Failed to backup module.</source>
         <translation>Nie udało się zapisać kopii zapasowej modułu.</translation>
     </message>
@@ -3721,70 +3721,70 @@
         <translation type="vanished">&lt;b&gt;YM2608 (OPNA) Music Tracker&lt;br&gt;Copyright (C) 2018-2020 Rerrah&lt;/b&gt;&lt;br&gt;&lt;hr&gt;Użyte biblioteki:&lt;br&gt;- C86CTL by (C) honet (BSD 3-Clause)&lt;br&gt;- libOPNMIDI by (C) Vitaly Novichkov (MIT License part)&lt;br&gt;- MAME (MAME License)&lt;br&gt;- Nuked OPN-MOD by (C) Alexey Khokholov (Nuke.YKT)&lt;br&gt;and (C) Jean Pierre Cimalando (LGPL v2.1)&lt;br&gt;- RtAudio by (C) Gary P. Scavone (RtAudio License)&lt;br&gt;- RtMidi by (C) Gary P. Scavone (RtMidi License)&lt;br&gt;- SCCI by (C) gasshi (SCCI License)&lt;br&gt;- Silk icons by (C) Mark James (CC BY 2.5 or 3.0)&lt;br&gt;- Qt (GPL v2+ or LGPL v3)&lt;br&gt;- VGMPlay by (C) Valley Bell (GPL v2)&lt;br&gt;&lt;br&gt;Zobacz także Changelog który wymienia wszystkich współautorów programu.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3194"/>
+        <location filename="../gui/mainwindow.cpp" line="3189"/>
         <source>Save module</source>
         <translation>Zapisz moduł</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3261"/>
+        <location filename="../gui/mainwindow.cpp" line="3256"/>
         <source>Open module</source>
         <translation>Otwórz moduł</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3331"/>
+        <location filename="../gui/mainwindow.cpp" line="3326"/>
         <source>Do you want to remove all unused instruments?</source>
         <translation>Czy chcesz usunąć wszystkie nieużywane instrumenty?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3352"/>
+        <location filename="../gui/mainwindow.cpp" line="3347"/>
         <source>Do you want to remove all unused patterns?</source>
         <translation>Czy chcesz usunąć wszystkie nieużywane wzorce?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3381"/>
-        <location filename="../gui/mainwindow.cpp" line="3415"/>
+        <location filename="../gui/mainwindow.cpp" line="3376"/>
+        <location filename="../gui/mainwindow.cpp" line="3410"/>
         <source>Export to WAV</source>
         <translation>Eksportuj do WAV</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3394"/>
-        <location filename="../gui/mainwindow.cpp" line="3527"/>
-        <location filename="../gui/mainwindow.cpp" line="3595"/>
+        <location filename="../gui/mainwindow.cpp" line="3389"/>
+        <location filename="../gui/mainwindow.cpp" line="3522"/>
+        <location filename="../gui/mainwindow.cpp" line="3590"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3516"/>
-        <location filename="../gui/mainwindow.cpp" line="3527"/>
+        <location filename="../gui/mainwindow.cpp" line="3511"/>
+        <location filename="../gui/mainwindow.cpp" line="3522"/>
         <source>Export to VGM</source>
         <translation>Eksportuj do VGM</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="3584"/>
-        <location filename="../gui/mainwindow.cpp" line="3595"/>
+        <location filename="../gui/mainwindow.cpp" line="3579"/>
+        <location filename="../gui/mainwindow.cpp" line="3590"/>
         <source>Export to S98</source>
         <translation>Eksportuj do S98</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="2257"/>
-        <location filename="../gui/mainwindow.cpp" line="2408"/>
-        <location filename="../gui/mainwindow.hpp" line="226"/>
-        <location filename="../gui/mainwindow.hpp" line="242"/>
+        <location filename="../gui/mainwindow.cpp" line="2252"/>
+        <location filename="../gui/mainwindow.cpp" line="2403"/>
+        <location filename="../gui/mainwindow.hpp" line="235"/>
+        <location filename="../gui/mainwindow.hpp" line="251"/>
         <source>Warning</source>
         <translation>Uwaga</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.hpp" line="227"/>
+        <location filename="../gui/mainwindow.hpp" line="236"/>
         <source>%1 If you execute this command, the command history is reset.</source>
         <translation>%1 Jeżeli wykonasz to polecenie, historia poleceń się zresetuje.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.hpp" line="235"/>
+        <location filename="../gui/mainwindow.hpp" line="244"/>
         <source>Could not open the audio stream. Please change the sound settings in Configuration.</source>
         <translation>Nie udało się otworzyć strumienia audio. Proszę zmienić ustawienia dźwięku w sekcji Kofiguracja.</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.hpp" line="243"/>
+        <location filename="../gui/mainwindow.hpp" line="252"/>
         <source>Could not set the sample rate of the audio stream to %1Hz. Currently the stream runs on %2Hz instead.</source>
         <translation>Nie udało się ustawić częstotliwośći próbkowania na %1Hz. Obecnie strumień działa na częstotliwości %2Hz.</translation>
     </message>
@@ -3921,12 +3921,12 @@
 <context>
     <name>ModuleSaveCheckDialog</name>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="108"/>
+        <location filename="../gui/mainwindow.cpp" line="105"/>
         <source>Save changes to %1?</source>
         <translation>Zapisać zmiany do %1?</translation>
     </message>
     <message>
-        <location filename="../gui/mainwindow.cpp" line="108"/>
+        <location filename="../gui/mainwindow.cpp" line="105"/>
         <source>Untitled</source>
         <translation>Bez nazwy</translation>
     </message>
@@ -3934,12 +3934,12 @@
 <context>
     <name>NotationSystem</name>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="71"/>
+        <location filename="../gui/configuration_dialog.cpp" line="72"/>
         <source>English</source>
         <translation type="unfinished">Angielski</translation>
     </message>
     <message>
-        <location filename="../gui/configuration_dialog.cpp" line="72"/>
+        <location filename="../gui/configuration_dialog.cpp" line="73"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4009,17 +4009,17 @@
 <context>
     <name>Panning</name>
     <message>
-        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="40"/>
+        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="41"/>
         <source>Left</source>
         <translation type="unfinished">Lewo</translation>
     </message>
     <message>
-        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="41"/>
+        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="42"/>
         <source>Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="42"/>
+        <location filename="../gui/instrument_editor/instrument_editor_drumkit_form.cpp" line="43"/>
         <source>Right</source>
         <translation type="unfinished">Prawo</translation>
     </message>
@@ -4392,12 +4392,12 @@
 <context>
     <name>SongType</name>
     <message>
-        <location filename="../gui/module_properties_dialog.cpp" line="37"/>
+        <location filename="../gui/module_properties_dialog.cpp" line="38"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gui/module_properties_dialog.cpp" line="38"/>
+        <location filename="../gui/module_properties_dialog.cpp" line="39"/>
         <source>FM3ch expanded</source>
         <translation type="unfinished"></translation>
     </message>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 - [#377] - Fixed error in loading .bti containing ADPCM samples larger than 65458B (thanks [@freq-mod])
 - [#334] - Fix CI (thanks [@OPNA2608])
 - [#344] - Fix document (thanks [@freq-mod])
-- [#390] - Fix lupdate errors/warnings ([#391]; thanks [@OPNA2608])
+- [#390] - Fix lupdate errors/warnings ([#391], [#392]; thanks [@OPNA2608])
 
 [@Mugenri]: https://github.com/Mugenri
 [@Speedvicio]: https://github.com/Speedvicio
@@ -107,6 +107,7 @@
 [#389]: https://github.com/BambooTracker/BambooTracker/pull/389
 [#390]: https://github.com/BambooTracker/BambooTracker/issues/390
 [#391]: https://github.com/BambooTracker/BambooTracker/pulls/391
+[#392]: https://github.com/BambooTracker/BambooTracker/pulls/392
 
 ## v0.4.6 (2021-02-11)
 ### Added


### PR DESCRIPTION
Fixes untranslated UI elements caused by #391.

- Notation style & Kit Panning:
![Bildschirmfoto_2021-07-15_16-12-29](https://user-images.githubusercontent.com/23431373/125803062-f3c3a7f6-7ddc-461c-9c61-b51cb6a7c928.png)

- Effect descriptions:
![Bildschirmfoto_2021-07-15_16-11-36](https://user-images.githubusercontent.com/23431373/125803068-f4c5bb8c-1fbb-4862-af0e-16c4f05e6ed5.png)

- Not sure how to test `file_io_error_message_box.cpp`.

- `module_properties_dialog.cpp` should be fixed, the translations just got unregistered which is out-of-scope for this PR.