### PR TITLE
Fix MSVC support

### DIFF
--- a/BambooTracker/bamboo_tracker.cpp
+++ b/BambooTracker/bamboo_tracker.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <utility>
 #include <exception>
+#include <iterator>
 #include <unordered_map>
 #include <unordered_set>
 #include "configuration.hpp"

--- a/BambooTracker/chip/mame/fmopn.c
+++ b/BambooTracker/chip/mame/fmopn.c
@@ -729,7 +729,7 @@ INLINE void FM_STATUS_RESET(FM_ST *ST,int flag)
 /* IRQ mask set */
 INLINE void FM_IRQMASK_SET(FM_ST *ST,int flag)
 {
-	ST->irqmask = flag;
+	ST->irqmask = (UINT8)flag;
 	/* IRQ handling check */
 	FM_STATUS_SET(ST,0);
 	FM_STATUS_RESET(ST,0);
@@ -1148,7 +1148,7 @@ INLINE void set_ar_ksr(UINT8 type, FM_CH *CH,FM_SLOT *SLOT,int v)
 
 	SLOT->ar = (v&0x1f) ? 32 + ((v&0x1f)<<1) : 0;
 
-	SLOT->KSR = 3-(v>>6);
+	SLOT->KSR = (UINT8)(3-(v>>6));
 	if (SLOT->KSR != old_KSR)
 	{
 		CH->SLOT[SLOT1].Incr=-1;
@@ -1540,7 +1540,7 @@ INLINE void refresh_fc_eg_slot(FM_OPN *OPN, FM_SLOT *SLOT , int fc , int kc )
 
 	if( SLOT->ksr != ksr )
 	{
-		SLOT->ksr = ksr;
+		SLOT->ksr = (UINT8)ksr;
 
 		/* calculate envelope generator rates */
 		if ((SLOT->ar + SLOT->ksr) < 32+62)
@@ -1727,7 +1727,7 @@ static void OPNWriteMode(FM_OPN *OPN, int r, int v)
 		OPN->ST.TA = (OPN->ST.TA & 0x3fc)|(v&3);
 		break;
 	case 0x26:  /* timer B */
-		OPN->ST.TB = v;
+		OPN->ST.TB = (UINT8)v;
 		break;
 	case 0x27:  /* mode, timer control */
 		set_timers( OPN, &(OPN->ST),OPN->ST.param,v );
@@ -1888,7 +1888,7 @@ static void OPNWriteReg(FM_OPN *OPN, int r, int v)
 		{
 		case 0:     /* 0xa0-0xa2 : FNUM1 */
 			if (OPN->LegacyMode)
-				OPN->ST.fn_h = CH->block_fnum >> 8;
+				OPN->ST.fn_h = (UINT8)(CH->block_fnum >> 8);
 			{
 				UINT32 fn = (((UINT32)( (OPN->ST.fn_h)&7))<<8) + v;
 				UINT8 blk = OPN->ST.fn_h>>3;
@@ -1910,7 +1910,7 @@ static void OPNWriteReg(FM_OPN *OPN, int r, int v)
 			break;
 		case 2:     /* 0xa8-0xaa : 3CH FNUM1 */
 			if (OPN->LegacyMode)
-				OPN->SL3.fn_h = OPN->SL3.block_fnum[c] >> 8;
+				OPN->SL3.fn_h = (UINT8)(OPN->SL3.block_fnum[c] >> 8);
 			if(r < 0x100)
 			{
 				UINT32 fn = (((UINT32)(OPN->SL3.fn_h&7))<<8) + v;
@@ -1941,7 +1941,7 @@ static void OPNWriteReg(FM_OPN *OPN, int r, int v)
 			{
 				int feedback = (v>>3)&7;
 				CH->ALGO = v&7;
-				CH->FB   = feedback ? feedback+6 : 0;
+				CH->FB   = (UINT8)(feedback ? feedback+6 : 0);
 				setup_connection( OPN, CH, c );
 			}
 			break;
@@ -2881,7 +2881,7 @@ static void FM_ADPCMAWrite(YM2610 *F2610,int r,int v)
 			else
 			{
 				adpcm[c].vol_mul   = 15 - (volume & 7);     /* so called 0.75 dB */
-				adpcm[c].vol_shift =  1 + (volume >> 3);    /* Yamaha engineers used the approximation: each -6 dB is close to divide by two (shift right) */
+				adpcm[c].vol_shift =  (UINT8)(1 + (volume >> 3));    /* Yamaha engineers used the approximation: each -6 dB is close to divide by two (shift right) */
 			}
 
 			/* calc pcm * volume data */
@@ -2909,7 +2909,7 @@ static void FM_ADPCMAWrite(YM2610 *F2610,int r,int v)
 			else
 			{
 				adpcm[c].vol_mul   = 15 - (volume & 7);     /* so called 0.75 dB */
-				adpcm[c].vol_shift =  1 + (volume >> 3);    /* Yamaha engineers used the approximation: each -6 dB is close to divide by two (shift right) */
+				adpcm[c].vol_shift =  (UINT8)(1 + (volume >> 3));    /* Yamaha engineers used the approximation: each -6 dB is close to divide by two (shift right) */
 			}
 
 			adpcm[c].pan    = &F2610->OPN.out_adpcm[(v>>6)&0x03];

--- a/BambooTracker/chip/mame/ymdeltat.c
+++ b/BambooTracker/chip/mame/ymdeltat.c
@@ -152,7 +152,7 @@ static const UINT8 dram_rightshift[4]={3,0,0,0};
 void YM_DELTAT_ADPCM_Write(YM_DELTAT *DELTAT,int r,int v)
 {
 	if(r>=0x10) return;
-	DELTAT->reg[r] = v; /* stock data */
+	DELTAT->reg[r] = (UINT8)v; /* stock data */
 
 	switch( r )
 	{
@@ -293,7 +293,7 @@ value:   START, REC, MEMDAT, REPEAT, SPOFF, x,x,RESET   meaning:
 				DELTAT->limit  = (DELTAT->reg[0xd]*0x0100 | DELTAT->reg[0xc]) << DELTAT->now_portshift;
 			}
 		}
-		DELTAT->control2 = v;
+		DELTAT->control2 = (UINT8)v;
 		break;
 	case 0x02:	/* Start Address L */
 	case 0x03:	/* Start Address H */
@@ -337,7 +337,7 @@ value:   START, REC, MEMDAT, REPEAT, SPOFF, x,x,RESET   meaning:
 
 			if ( DELTAT->now_addr != (DELTAT->end<<1) )
 			{
-				DELTAT->memory[(DELTAT->now_addr>>1)&DELTAT->memory_mask] = v;
+				DELTAT->memory[(DELTAT->now_addr>>1)&DELTAT->memory_mask] = (UINT8)v;
 				DELTAT->now_addr+=2; /* two nibbles at a time */
 
 				/* reset BRDY bit in status register, which means we are processing the write */
@@ -366,7 +366,7 @@ value:   START, REC, MEMDAT, REPEAT, SPOFF, x,x,RESET   meaning:
 		/* ADPCM synthesis from CPU */
 		if ( (DELTAT->portstate & 0xe0)==0x80 )
 		{
-			DELTAT->CPU_data = v;
+			DELTAT->CPU_data = (UINT8)v;
 
 			/* Reset BRDY bit in status register, which means we are full of data */
 			if (DELTAT->status_reset_handler && DELTAT->status_change_BRDY_bit)
@@ -438,7 +438,7 @@ void YM_DELTAT_ADPCM_Reset(YM_DELTAT *DELTAT,int pan)
 	DELTAT->step      = 0;
 	DELTAT->start     = 0;
 	DELTAT->end       = 0;
-	DELTAT->limit     = ~0; /* this way YM2610 and Y8950 (both of which don't have limit address reg) will still work */
+	DELTAT->limit     = (UINT32)~0; /* this way YM2610 and Y8950 (both of which don't have limit address reg) will still work */
 	DELTAT->volume    = 0;
 	DELTAT->pan       = &DELTAT->output_pointer[pan];
 	DELTAT->acc       = 0;

--- a/BambooTracker/chip/nuked/ym3438.c
+++ b/BambooTracker/chip/nuked/ym3438.c
@@ -335,7 +335,7 @@ void OPN2_DoRegWrite(ym3438_t *chip)
     if (chip->write_fm_data)
     {
         /* Slot */
-        if (op_offset[slot] == (chip->address & 0x107))
+        if (op_offset[slot] == (Bit32u)(chip->address & 0x107))
         {
             if (chip->address & 0x08)
             {
@@ -385,7 +385,7 @@ void OPN2_DoRegWrite(ym3438_t *chip)
         }
 
         /* Channel */
-        if (ch_offset[channel] == (chip->address & 0x103))
+        if (ch_offset[channel] == (Bit32u)(chip->address & 0x103))
         {
             address = chip->address & 0xfc;
             switch (address)
@@ -393,7 +393,7 @@ void OPN2_DoRegWrite(ym3438_t *chip)
             case 0xa0:
                 chip->fnum[channel] = (chip->data & 0xff) | ((chip->reg_a4 & 0x07) << 8);
                 chip->block[channel] = (chip->reg_a4 >> 3) & 0x07;
-                chip->kcode[channel] = (chip->block[channel] << 2) | fn_note[chip->fnum[channel] >> 7];
+                chip->kcode[channel] = (Bit8u)((chip->block[channel] << 2) | fn_note[chip->fnum[channel] >> 7]);
                 break;
             case 0xa4:
                 chip->reg_a4 = chip->data & 0xff;

--- a/BambooTracker/chip/register_write_logger.cpp
+++ b/BambooTracker/chip/register_write_logger.cpp
@@ -66,7 +66,7 @@ std::vector<uint8_t> AbstractRegisterWriteLogger::getData()
 
 size_t AbstractRegisterWriteLogger::getSampleLength() const noexcept
 {
-	return totalSampCnt_;
+	return static_cast<size_t>(totalSampCnt_);
 }
 
 size_t AbstractRegisterWriteLogger::setLoopPoint()
@@ -113,7 +113,7 @@ void VgmLogger::recordRegisterChange(uint32_t offset, uint8_t value)
 
 	if (cmdSsg && offset < 0x10) {
 		buf_.push_back(cmdSsg);
-		buf_.push_back(offset);
+		buf_.push_back(static_cast<uint8_t>(offset));
 		buf_.push_back(value);
 	}
 	else if (cmdFmPortA && (offset & 0x100) == 0) {
@@ -173,7 +173,7 @@ void VgmLogger::setWait()
 
 		if (intrRate_ == 50) {
 			if (lastWait_ > 65535) {
-				uint32_t tmp = lastWait_ - 65535;
+				uint32_t tmp = static_cast<uint32_t>(lastWait_ - 65535);
 				if (tmp <= 882) {
 					//65535 - (882 - tmp)
 					sub = 64653 + tmp;
@@ -191,16 +191,16 @@ void VgmLogger::setWait()
 				}
 				buf_.push_back(0x61);
 				buf_.push_back(sub & 0x00ff);
-				buf_.push_back(sub >> 8);
+				buf_.push_back(static_cast<uint8_t>(sub >> 8));
 			}
 			else {
 				if (lastWait_ <= 16) {
-					buf_.push_back(0x70 | (lastWait_ - 1));
+					buf_.push_back(static_cast<uint8_t>(0x70 | (lastWait_ - 1)));
 				}
 				else if (lastWait_ > 2646) {
 					buf_.push_back(0x61);
 					buf_.push_back(lastWait_ & 0x00ff);
-					buf_.push_back(lastWait_ >> 8);
+					buf_.push_back(static_cast<uint8_t>(lastWait_ >> 8));
 				}
 				else if (lastWait_ == 2646) {
 					buf_.push_back(0x63);
@@ -208,27 +208,27 @@ void VgmLogger::setWait()
 					buf_.push_back(0x63);
 				}
 				else if (1764 <= lastWait_ && lastWait_ <= 1780) {
-					uint32_t tmp = lastWait_ - 1764;
+					uint32_t tmp = static_cast<uint32_t>(lastWait_ - 1764);
 					buf_.push_back(0x63);
 					buf_.push_back(0x63);
 					if (tmp) buf_.push_back(0x70 | (tmp - 1));
 				}
 				else if (882 <= lastWait_ && lastWait_ <= 898) {
-					uint32_t tmp = lastWait_ - 882;
+					uint32_t tmp = static_cast<uint32_t>(lastWait_ - 882);
 					buf_.push_back(0x63);
 					if (tmp) buf_.push_back(0x70 | (tmp - 1));
 				}
 				else {
 					buf_.push_back(0x61);
 					buf_.push_back(lastWait_ & 0x00ff);
-					buf_.push_back(lastWait_ >> 8);
+					buf_.push_back(static_cast<uint8_t>(lastWait_ >> 8));
 				}
-				sub = lastWait_;
+				sub = static_cast<uint32_t>(lastWait_);
 			}
 		}
 		else if (intrRate_ == 60) {
 			if (lastWait_ > 65535) {
-				uint32_t tmp = lastWait_ - 65535;
+				uint32_t tmp = static_cast<uint32_t>(lastWait_ - 65535);
 				if (tmp <= 735) {
 					//65535 - (735 - tmp)
 					sub = 64800 + tmp;
@@ -250,12 +250,12 @@ void VgmLogger::setWait()
 			}
 			else {
 				if (lastWait_ <= 16) {
-					buf_.push_back(0x70 | (lastWait_ - 1));
+					buf_.push_back(static_cast<uint8_t>(0x70 | (lastWait_ - 1)));
 				}
 				else if (lastWait_ > 2205) {
 					buf_.push_back(0x61);
 					buf_.push_back(lastWait_ & 0x00ff);
-					buf_.push_back(lastWait_ >> 8);
+					buf_.push_back(static_cast<uint8_t>(lastWait_ >> 8));
 				}
 				else if (lastWait_ == 2205) {
 					buf_.push_back(0x62);
@@ -263,22 +263,22 @@ void VgmLogger::setWait()
 					buf_.push_back(0x62);
 				}
 				else if (1470 <= lastWait_ && lastWait_ <= 1486) {
-					uint32_t tmp = lastWait_ - 1470;
+					uint32_t tmp = static_cast<uint32_t>(lastWait_ - 1470);
 					buf_.push_back(0x62);
 					buf_.push_back(0x62);
 					if (tmp) buf_.push_back(0x70 | (tmp - 1));
 				}
 				else if (735 <= lastWait_ && lastWait_ <= 751) {
-					uint32_t tmp = lastWait_ - 735;
+					uint32_t tmp = static_cast<uint32_t>(lastWait_ - 735);
 					buf_.push_back(0x62);
 					if (tmp) buf_.push_back(0x70 | (tmp - 1));
 				}
 				else {
 					buf_.push_back(0x61);
 					buf_.push_back(lastWait_ & 0x00ff);
-					buf_.push_back(lastWait_ >> 8);
+					buf_.push_back(static_cast<uint8_t>(lastWait_ >> 8));
 				}
-				sub = lastWait_;
+				sub = static_cast<uint32_t>(lastWait_);
 			}
 		}
 		else {
@@ -291,9 +291,9 @@ void VgmLogger::setWait()
 			else {
 				buf_.push_back(0x61);
 				buf_.push_back(lastWait_ & 0x00ff);
-				buf_.push_back(lastWait_ >> 8);
+				buf_.push_back(static_cast<uint8_t>(lastWait_ >> 8));
 			}
-			sub = lastWait_;
+			sub = static_cast<uint32_t>(lastWait_);
 		}
 
 		lastWait_ -= sub;

--- a/BambooTracker/chip/register_write_logger.cpp
+++ b/BambooTracker/chip/register_write_logger.cpp
@@ -26,6 +26,7 @@
 #include "register_write_logger.hpp"
 #include "io/export_io.hpp"
 #include <algorithm>
+#include <iterator>
 
 namespace chip
 {

--- a/BambooTracker/command/pattern/paste_insert_copied_data_to_pattern_command.cpp
+++ b/BambooTracker/command/pattern/paste_insert_copied_data_to_pattern_command.cpp
@@ -25,6 +25,7 @@
 
 #include "paste_insert_copied_data_to_pattern_command.hpp"
 #include <algorithm>
+#include <iterator>
 #include "pattern_command_utils.hpp"
 
 PasteInsertCopiedDataToPatternCommand::PasteInsertCopiedDataToPatternCommand(

--- a/BambooTracker/gui/order_list_editor/order_list_panel.cpp
+++ b/BambooTracker/gui/order_list_editor/order_list_panel.cpp
@@ -624,6 +624,9 @@ void OrderListPanel::quickDrawRows(int maxWidth)
 
 void OrderListPanel::drawHeaders(int maxWidth)
 {
+	static const QString RHYTM_NAMES[6] = {
+		"BD", "SD", "TOP", "HH", "TOM", "RIM"
+	};
 	QPainter painter(&headerPixmap_);
 	painter.setFont(headerFont_);
 
@@ -658,9 +661,6 @@ void OrderListPanel::drawHeaders(int maxWidth)
 			str = "SG" + QString::number(attrib.channelInSource + 1);
 			break;
 		case SoundSource::RHYTHM:
-			static const QString RHYTM_NAMES[6] = {
-				"BD", "SD", "TOP", "HH", "TOM", "RIM"
-			};
 			str = RHYTM_NAMES[attrib.channelInSource];
 			break;
 		case SoundSource::ADPCM:

--- a/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
+++ b/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
@@ -1215,7 +1215,7 @@ void PatternEditorPanel::moveCursorToRight(int n)
 		emit currentTrackChanged(curPos_.trackVisIdx);
 
 	// Request fore-background repaint if leftmost track is changed else request only background repaint
-	if (leftTrackVisIdx_ != oldLeftTrackIdx) {
+	if (static_cast<bool>(leftTrackVisIdx_&1) != oldLeftTrackIdx) {
 		headerChanged_ = true;
 		foreChanged_ = true;
 		textChanged_ = true;

--- a/BambooTracker/note.cpp
+++ b/BambooTracker/note.cpp
@@ -1132,7 +1132,7 @@ void Note::evaluateState(int octave, int note, int pitch)
 	pitch_ = pitch % SEMINOTE_PITCH;
 	note += pitch / SEMINOTE_PITCH;
 	name_ = ((note % 12) + 12) % 12;;
-	octave_ = octave + std::floor(note / 12.);
+	octave_ = (int)(octave + std::floor(note / 12.));
 	if (octave_ < 0 || (!octave_ && !name_ && pitch_ < 0)) {
 		octave_ = 0;
 		name_ = NoteName::C;

--- a/BambooTracker/utils.hpp
+++ b/BambooTracker/utils.hpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <type_traits>
 #include <vector>
+#include <iterator>
 
 namespace utils
 {

--- a/qmake/variables.pri
+++ b/qmake/variables.pri
@@ -32,9 +32,9 @@ message("Qt is version" $$QT_VERSION)
 msvc|clang|if(gcc:!intel_icc) {
   msvc {
     message("Configured compiler is MSVC")
-    # Pure speculation based on documentation and qmake mkspecs
-    CPP_WARNING_FLAGS += /Wall /Wp64 /WX
+    CPP_WARNING_FLAGS += /W3 /WX
     CPP_WARNING_FLAGS += /utf-8
+    CPP_WARNING_FLAGS += /D_CRT_SECURE_NO_WARNINGS # non _s functions cause errors, cross-platform support for them is terrible
     COMPILER_MAJOR_VERSION = $$QT_MSC_VER
     COMPILER_MINOR_VERSION = $$QT_MSC_FULL_VER
     COMPILER_MINOR_VERSION ~= s/^$$QT_MSC_VER//


### PR DESCRIPTION
This PR fixes support for building with MSVC (at least a recent version of it).

Downgrades the strictness of the MSVC compiler flags due to *many* problems that are either too ridiculous (undefined compiler macros -> error) or too complicated (errors in Qt's own headers, should use MSVC equivalent of `-isystem` but those includes come from Qmake spec files) to resolve nicely.

Any support for MSVC is better than no support though :smile:.

CC @djtuBIG-MaliceX