### PR TITLE
Fix bug where pattern header was sometimes not redrawn

### DIFF
--- a/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
+++ b/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
@@ -1140,7 +1140,7 @@ int PatternEditorPanel::calculateColNumInRow(int trackVisIdx, int colNumInTrack,
 void PatternEditorPanel::moveCursorToRight(int n)
 {
 	int oldTrackIdx = curPos_.trackVisIdx;
-	bool oldLeftTrackIdx = leftTrackVisIdx_;
+	int oldLeftTrackIdx = leftTrackVisIdx_;
 
 	curPos_.colInTrack += n;
 	if (n > 0) {
@@ -1215,7 +1215,7 @@ void PatternEditorPanel::moveCursorToRight(int n)
 		emit currentTrackChanged(curPos_.trackVisIdx);
 
 	// Request fore-background repaint if leftmost track is changed else request only background repaint
-	if (static_cast<bool>(leftTrackVisIdx_&1) != oldLeftTrackIdx) {
+	if (leftTrackVisIdx_ != oldLeftTrackIdx) {
 		headerChanged_ = true;
 		foreChanged_ = true;
 		textChanged_ = true;


### PR DESCRIPTION
In 0.5.0 and before, pressing Shift+Tab repeatedly until you reach FM 2 will fail to redraw the header, because `oldLeftTrackIdx` was erroneously declared a `bool`.

In builds since accb5ac5f64a82560fff775f9a36f1a4642007d6 (https://github.com/BambooTracker/BambooTracker/commit/accb5ac5f64a82560fff775f9a36f1a4642007d6#diff-97d96a2c599e40b88ae7e016d1b61a16bbb5cb81d4ef24f08c83fa5e8f2307fb) (more recent than 0.5.0), placing the cursor in the leftmost column, then pressing Shift+Tab to jump to the right an even number of columns, will fail to redraw the header, and 1 of every 2 subsequent Shift+Tab presses will fail to redraw. This is due to the bizarre `static_cast<bool>(leftTrackVisIdx_&1) != oldLeftTrackIdx` comparison.

This fixes both problems by declaring `oldLeftTrackIdx` as an `int`, and comparing it to `leftTrackVisIdx_` directly.