### PR TITLE
Implement pattern/order editor DPI scaling, fix pixellation on Qt 6 HiDPI

### DIFF
--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -238,6 +238,7 @@ HEADERS += \
     gui/command/order/order_commands_qt.hpp \
     gui/command/order/order_list_common_qt_command.hpp \
     gui/command/pattern/pattern_editor_common_qt_command.hpp \
+    gui/dpi.hpp \
     gui/drop_detect_list_widget.hpp \
     gui/effect_description.hpp \
     gui/effect_list_dialog.hpp \

--- a/BambooTracker/gui/dpi.hpp
+++ b/BambooTracker/gui/dpi.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QWidget>
+#include <QPixmap>
+
+namespace Dpi
+{
+
+inline QPixmap scaledQPixmap(QSize size, int ratio)
+{
+	QPixmap out(size * ratio);
+	out.setDevicePixelRatio(ratio);
+	return out;
+}
+
+inline QPixmap scaledQPixmap(int width, int height, int ratio)
+{
+	QPixmap out(width * ratio, height * ratio);
+	out.setDevicePixelRatio(ratio);
+	return out;
+}
+
+inline int iRatio(QWidget const& w)
+{
+	// devicePixelRatio is int on Qt 5 and qreal on Qt 6.
+	// This shouldn't result in *too many* behavior differences though,
+	// since devicePixelRatioF is an integer on Qt 5,
+	// unless KDE sets QT_SCREEN_SCALE_FACTORS (we can't workaround)
+	// or we set DPI scaling to PassThrough (we don't).
+	auto ratio = w.devicePixelRatio();
+
+	// Fails on Linux KDE due to https://bugreports.qt.io/browse/QTBUG-95930.
+	// Q_ASSERT((int) ratio == ratio);
+
+	return (int) ratio;
+}
+
+inline QRect scaleRect(QRect rect, int ratio)
+{
+	// QRect is insane. QRectF is sane.
+	// QRect(QPoint(0, 0), QSize(10, 10)).right() == 9
+	// QRectF(QPointF(0., 0.), QSizeF(10., 10.)).right() == 10.
+	return QRect(rect.topLeft() * ratio, rect.size() * ratio);
+}
+
+} // namespace

--- a/BambooTracker/main.cpp
+++ b/BambooTracker/main.cpp
@@ -55,7 +55,9 @@ int main(int argc, char* argv[])
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 		QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
-
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+		QApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::RoundPreferFloor);
+#endif
 		QApplicationWrapper a(argc, argv);
 		if (config->getEnableTranslation()) setupTranslations();
 		a.setWindowIcon(QIcon(":/icon/app_icon"));

--- a/BambooTracker/main.cpp
+++ b/BambooTracker/main.cpp
@@ -56,15 +56,15 @@ int main(int argc, char* argv[])
 		QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 
-		std::unique_ptr<QApplicationWrapper> a(std::make_unique<QApplicationWrapper>(argc, argv));
+		QApplicationWrapper a(argc, argv);
 		if (config->getEnableTranslation()) setupTranslations();
-		a->setWindowIcon(QIcon(":/icon/app_icon"));
+		a.setWindowIcon(QIcon(":/icon/app_icon"));
 
 		QString filePath = (argc > 1) ? argv[argc - 1] : "";	// Last argument file
 
-		std::unique_ptr<MainWindow> w(std::make_unique<MainWindow>(config, filePath, !hasSuccessed));
-		w->show();
-		int ret = a->exec();
+		MainWindow w(config, filePath, !hasSuccessed);
+		w.show();
+		int ret = a.exec();
 
 		io::saveConfiguration(config);
 		if (ret) QMessageBox::critical(nullptr, QObject::tr("Error"), QObject::tr("An unknown error occurred."));


### PR DESCRIPTION
This PR was mostly tested on Windows 10 x64 at various DPI settings. It fails on Qt 5 and 6 on KDE, due to KDE/Qt bugs rather than my code or BambooTracker's code. I did not test on Mac.

Honestly I did this mostly out of personal interest and for learning, since I'm not sure if other people use high DPI displays *or* Qt 6. However it serves as a demonstration that pixel-perfect fractional DPI scaling is possible on Qt 6 (which I thought was impossible until recently) through `HighDpiScaleFactorRoundingPolicy`. And this may become more important as Qt 5 transitions into a legacy program over time.

## Overview

Qt 6 forces applications to use virtual pixels rather than physical pixels. This makes it difficult to perform pixel-level paint operations on widgets, or to create a QPixmap/QImage the same size as a widget. Worse yet, at fractional scale factors (physical pixels per virtual pixel), it's impossible to convert a widget size in virtual pixels to an image size in physical pixels, and have them always match up entirely.

I use `HighDpiScaleFactorRoundingPolicy::RoundPreferFloor` so Qt make each virtual pixel an integer number of physical pixels. Then when calling functions that take physical pixels, I multiply the size in virtual pixels by the integer scale factor. The only functions I've found so far that take physical pixels are `QPixmap`'s constructor (taking a size in physical pixels), calling `QPainter::drawPixmap()` (taking a source rect in physical pixels), or calling `QPixmap::scroll()` for quick draw (both delta and region in physical pixels). If I've missed any, then it would result in redrawing defects. The current version of the PR has all rendering defects I've seen so far fixed.

(All QPainter operations acting *on* a `QPixmap`/`QWidget`, both of which implement `QPaintDevice`, multiply all coordinates by the target's `QPaintDevice::devicePixelRatio[F]()`.)

## Results

I rewrote the pattern and order editors to look sharp at high DPIs. I didn't touch the oscilloscope (which for some reason draws individual points rather than lines, meaning it's not antialiased) or the FM/PSG/ADPCM instrument editors.

The resulting app looks sharp, and lines are appropriately thick, on both 125% and 200% scaling, on both Qt 5 and 6. However, this approach does have some flaws: At 125-150% scaling, elements defined in terms of pixel count rather than font size (I don't think BambooTracker's pattern editor does this, unsure about instrument editor) do not scale compared to 100% (though this can be fixed with more work). At 200% scaling, positions are quantized to multiples of 2 pixels (though this isn't a deal-breaker). Nonetheless this is the best approach achievable on Qt (to my knowledge) if you want sharp and uniformly thick lines.

<details><summary>What are the alternative approaches?</summary>

Eliminating virtual pixels entirely, and positioning all widgets in physical pixels (increasing line thicknesses at high DPI unless you want to upset 200%/300% users), is not possible on Qt 6+ (not sure about 5, not sure about AA_DisableHighDpiScaling).

Another approach option is virtual pixels or vector graphics, then performing DPI scaling by rendering at a higher resolution. (If no intrinsic grid, will be fuzzy at all resolutions, if intrinsic grid, will be fuzzy at non-integer scale, unless UI elements are grid-snapped to integer physical pixels). This is the approach taken by many VST GUIs, and `HighDpiScaleFactorRoundingPolicy::PassThrough` kinda works like this. However the usual approach of using alpha-blended antialiasing (rather than multisampling/etc.) means coinciding edges at non-integer pixel boundaries are drawn incorrectly ("conflation artifacts"). Additionally BambooTracker's use of multiple off-screen `QPixmap` rather than painting directly to the widget isn't how vector graphics works, and makes it difficult to impossible (not sure which) to even size the `QPixmap` to the same resolution as the widgets being painted on (which can be seen as a special case of non-integer edges).
</details>

One possible concern with this PR that rendering at full pixel resolution will slow down pattern redrawing at high resolutions. I'm not sure if it's worth adding an application-level setting to control whether to render at virtual resolution rather than physical resolution (at 200% DPI, only render 1/2 of pixels horizontally and vertically, and upscale using nearest or linear interpolation).

## Bugs

Unfortunately `HighDpiScaleFactorRoundingPolicy` has no effect on Linux KDE due to [QTBUG-95930](https://bugreports.qt.io/browse/QTBUG-95930) (which I reported but has not been fixed), so this PR won't fix inconsistent pixel sizes there (I suggest setting display scaling to 100% and boosting font DPI instead).

Additionally, switching DPI after launching the app causes broken pattern/order editor layout, until you open the settings and click Apply to recompute font metrics. This is because BambooTracker isn't designed to switch DPIs. (Switching the DPI of running apps is easy on Windows, but probably not possible on Linux KDE X11 without manually the `Xft/DPI` XSettings variable, which I think KDE doesn't touch or Qt doesn't pick up. No clue about Wayland.)

Additionally switching DPI without switching `QScreen` objects (changing screen DPI, or switching between "laptop only" and "monitor only") is broken in Qt itself with `HighDpiScaleFactorRoundingPolicy` set, due to [QTBUG-95925](https://bugreports.qt.io/browse/QTBUG-95925) and related bugs. I have a [workaround](https://gist.github.com/nyanpasu64/42a57df53e2de52e5f89a25cdf2730d4) to fix this bug, but I think it belongs in a separate PR if it's even approved at all.

Additionally at 2x integer scaling and up (175% and higher OS scale factor), the "bottom line" of the pattern/order editor's headers is misplaced too high, creating a gray line at the bottom of the header. This is a BambooTracker bug exposed by high scale factors, and ~~I didn't fix it because it's minor and shifting a line is not strictly related to the rest of the PR (which adds/fixes scaling factors)~~ I added a surgical fix. To avoid this kind of bug, in exotracker, I avoided `QRect`'s lines and rectangle outlines entirely in favor of my own rectangle left/right border functions.

## Code Style

I was rather sloppy with the code style and didn't match the project (`#pragma once`, removing trailing whitespace from files I touched, placing open braces on the same line as the function, not sure how to break long lines, etc.) So I marked the PR as a draft.

## Screenshots on Qt 6

Before (125%):

![BambooTracker_S9Ny9OJ3e9](https://user-images.githubusercontent.com/913957/130368607-39b4d314-3e1c-4ff0-a874-b302500640b9.png)

After (125%):

![BambooTracker_S1NaAwPYOh](https://user-images.githubusercontent.com/913957/130368629-efd69760-f8f1-48a6-94ad-f2f5d41eec85.png)

After (200%):

![BambooTracker_Hw747hrL0H](https://user-images.githubusercontent.com/913957/130368446-5db5750a-c044-448b-95b2-5f56342d21bf.png)

Qt 5 looks uglier since the window font doesn't scale with DPI, even at 200%. Maybe `Qt::AA_EnableHighDpiScaling` would help, or the `QApplication::setFont(QApplication::font("QMessageBox"));` trick.