### PR TITLE
Bump AppVeyor Win7 Qt version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,9 +33,9 @@ environment:
   matrix:
     # Windows 7 or later
     - APPVEYOR_JOB_NAME: for Windows (7 or later)
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      COMPILER: C:\Qt\Tools\mingw530_32\bin
-      QT: C:\Qt\5.10.1\mingw53_32\bin
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      COMPILER: C:\Qt\Tools\mingw810_32\bin
+      QT: C:\Qt\5.15.2\mingw81_32\bin
       PLATFORM: windows
       DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-dev-windows-7-32bit.zip
       MAKE: mingw32-make


### PR DESCRIPTION
https://github.com/BambooTracker/BambooTracker/pull/407#issuecomment-903810051

> > the AppVeyor Windows 7 builds are being made on 5.10.1 rather than the latest 5.15.2 (should this be changed?)
> > *and* fail to be incorporated into dev builds
> 
> AppVeyor build stuff wasn't really touched in awhile. The dissonance in Qt versions between GHA & AV is due to negligence of the latter and not intentional. We can make a PR bumping the builder image to Visual Studio 2019 and pinning the Qt version to MinGW 5.15.2 to address this.