### PR TITLE
Fix instrument editor envelope graphs on Breeze master

### DIFF
--- a/BambooTracker/gui/instrument_editor/fm_operator_table.cpp
+++ b/BambooTracker/gui/instrument_editor/fm_operator_table.cpp
@@ -108,7 +108,8 @@ FMOperatorTable::FMOperatorTable(QWidget *parent) :
 		if (!isIgnoreEvent_) emit operatorValueChanged(Ui::FMOperatorParameter::SSGEG, value);
 	});
 
-	ui->envFrame->installEventFilter(this);
+	ui->envGraph->setBackgroundRole(QPalette::Base);
+	ui->envGraph->installEventFilter(this);
 }
 
 FMOperatorTable::~FMOperatorTable()
@@ -204,11 +205,10 @@ QString FMOperatorTable::toString() const
 
 bool FMOperatorTable::eventFilter(QObject* obj, QEvent* event)
 {
-	if (obj == ui->envFrame) {
+	if (obj == ui->envGraph) {
 		if (event->type() == QEvent::Paint) {
-			QPainter painter(ui->envFrame);
-			painter.eraseRect(ui->envFrame->rect());
-			painter.drawPixmap(ui->envFrame->rect(), envmap_, envmap_.rect());
+			QPainter painter(ui->envGraph);
+			painter.drawPixmap(ui->envGraph->rect(), envmap_, envmap_.rect());
 		}
 	}
 
@@ -229,7 +229,13 @@ void FMOperatorTable::resizeEvent(QResizeEvent*)
 
 void FMOperatorTable::resizeGraph()
 {
-	envmap_ = QPixmap(ui->envFrame->size());
+	// Resize the graph widget to fill the entire QFrame.
+	// This avoids issues (eg. on the adwaita-qt theme)
+	// where the graph is surrounded by wide margins.
+	// The edges may be cut off, but it's not an issue in practice.
+	ui->envGraph->setGeometry(ui->envFrame->rect());
+
+	envmap_ = QPixmap(ui->envGraph->size());
 	xr_ = (envmap_.width() - (ENV_LINE_W_ + 1) * 2.) / ENV_W_;
 	yr_ = (envmap_.height() - (ENV_LINE_W_ + 1) * 2.) / ENV_H_;
 }
@@ -425,7 +431,7 @@ void FMOperatorTable::repaintGraph()
 		}
 	}
 
-	ui->envFrame->repaint();
+	ui->envGraph->repaint();
 }
 
 void FMOperatorTable::on_ssgegCheckBox_stateChanged(int)

--- a/BambooTracker/gui/instrument_editor/fm_operator_table.ui
+++ b/BambooTracker/gui/instrument_editor/fm_operator_table.ui
@@ -271,6 +271,8 @@
         <property name="lineWidth">
          <number>1</number>
         </property>
+        <widget class="QWidget" name="envGraph" native="true">
+        </widget>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
Previously FMOperatorTable would paint a custom graph on a QFrame. On KDE's upcoming Breeze theme revision, the QFrame overwrites the contents of the graph by filling it with a background color.

I changed the QFrame to add a placeholder child QWidget, which I made to fill the QFrame using a placeholder vertical layout with zero content margins. The child QWidget has `native="true"`, which sounds scary (in Qt, native widgets have their own HWND or the X11 equivalent, which is undesirable here), but the generated C++ code doesn't actually mention `native` at all. [Stack Overflow says](https://stackoverflow.com/questions/6257908/what-does-native-true-stand-for-in-a-qt-designer-form) `native="true"` marks the widget as using native theming, but I'm not sure about that explanation.

The alternative is to not put a child widget in the QFrame, but instead set the QFrame to have no borders. But I think that would look uglier, since the result wouldn't have a frame border.

Fixes #403.

(I have a similar commit, not in this PR yet, for surrounding the wave viewer oscilloscope with a QFrame.)

----

In Qt, what's the best way to give a custom-painted widget a border, but make it not count towards the `sizeHint()` or `width()` or the `QPainter`-accessible area? Surround it in a `QFrame`? Now the owning widget needs to insert the QFrame into the layout, but communicate with its child widget.

QGraphicsView and QAbstractItemView instead inherit from QAbstractScrollArea, and place the custom logic in the parent widget instead of the child (which is a base-class QWidget). But placing custom logic in the owner/parent which draws onto a child feels awkward to me (and I don't know how to manage it), and inheriting from QAbstractScrollArea feels unsuited for non-scrolling widgets.