### PR TITLE
Keep instrument editors on top of main window, spawn centered

### DIFF
--- a/BambooTracker/gui/instrument_editor/instrument_editor_adpcm_form.cpp
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_adpcm_form.cpp
@@ -33,7 +33,7 @@
 #include "gui/gui_utils.hpp"
 
 InstrumentEditorADPCMForm::InstrumentEditorADPCMForm(int num, QWidget *parent) :
-	QWidget(parent),
+	QDialog(parent),
 	ui(new Ui::InstrumentEditorADPCMForm),
 	instNum_(num),
 	isIgnoreEvent_(false)

--- a/BambooTracker/gui/instrument_editor/instrument_editor_adpcm_form.hpp
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_adpcm_form.hpp
@@ -27,7 +27,7 @@
 #define INSTRUMENT_EDITOR_ADPCM_FORM_HPP
 
 #include <memory>
-#include <QWidget>
+#include <QDialog>
 #include <QKeyEvent>
 #include "bamboo_tracker.hpp"
 #include "configuration.hpp"
@@ -39,7 +39,7 @@ namespace Ui {
 	class InstrumentEditorADPCMForm;
 }
 
-class InstrumentEditorADPCMForm : public QWidget
+class InstrumentEditorADPCMForm : public QDialog
 {
 	Q_OBJECT
 

--- a/BambooTracker/gui/instrument_editor/instrument_editor_adpcm_form.ui
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_adpcm_form.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>InstrumentEditorADPCMForm</class>
- <widget class="QWidget" name="InstrumentEditorADPCMForm">
+ <widget class="QDialog" name="InstrumentEditorADPCMForm">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/BambooTracker/gui/instrument_editor/instrument_editor_drumkit_form.cpp
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_drumkit_form.cpp
@@ -52,7 +52,7 @@ inline int convertPanInternalToUi(int intrPan)
 }
 
 InstrumentEditorDrumkitForm::InstrumentEditorDrumkitForm(int num, QWidget *parent) :
-	QWidget(parent),
+	QDialog(parent),
 	ui(new Ui::InstrumentEditorDrumkitForm),
 	instNum_(num),
 	isIgnoreEvent_(false),

--- a/BambooTracker/gui/instrument_editor/instrument_editor_drumkit_form.hpp
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_drumkit_form.hpp
@@ -27,7 +27,7 @@
 #define INSTRUMENT_EDITOR_DRUMKIT_FORM_HPP
 
 #include <memory>
-#include <QWidget>
+#include <QDialog>
 #include <QKeyEvent>
 #include <QTreeWidgetItem>
 #include "bamboo_tracker.hpp"
@@ -39,7 +39,7 @@ namespace Ui {
 	class InstrumentEditorDrumkitForm;
 }
 
-class InstrumentEditorDrumkitForm : public QWidget
+class InstrumentEditorDrumkitForm : public QDialog
 {
 	Q_OBJECT
 

--- a/BambooTracker/gui/instrument_editor/instrument_editor_drumkit_form.ui
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_drumkit_form.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>InstrumentEditorDrumkitForm</class>
- <widget class="QWidget" name="InstrumentEditorDrumkitForm">
+ <widget class="QDialog" name="InstrumentEditorDrumkitForm">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/BambooTracker/gui/instrument_editor/instrument_editor_fm_form.cpp
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_fm_form.cpp
@@ -44,7 +44,7 @@
 #include "gui/gui_utils.hpp"
 
 InstrumentEditorFMForm::InstrumentEditorFMForm(int num, QWidget *parent) :
-	QWidget(parent),
+	QDialog(parent),
 	ui(new Ui::InstrumentEditorFMForm),
 	instNum_(num),
 	isIgnoreEvent_(false)

--- a/BambooTracker/gui/instrument_editor/instrument_editor_fm_form.hpp
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_fm_form.hpp
@@ -26,7 +26,7 @@
 #ifndef INSTRUMENT_EDITOR_FM_FORM_HPP
 #define INSTRUMENT_EDITOR_FM_FORM_HPP
 
-#include <QWidget>
+#include <QDialog>
 #include <QKeyEvent>
 #include <QResizeEvent>
 #include <QShowEvent>
@@ -42,7 +42,7 @@ namespace Ui {
 	class InstrumentEditorFMForm;
 }
 
-class InstrumentEditorFMForm : public QWidget
+class InstrumentEditorFMForm : public QDialog
 {
 	Q_OBJECT
 

--- a/BambooTracker/gui/instrument_editor/instrument_editor_fm_form.ui
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_fm_form.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>InstrumentEditorFMForm</class>
- <widget class="QWidget" name="InstrumentEditorFMForm">
+ <widget class="QDialog" name="InstrumentEditorFMForm">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/BambooTracker/gui/instrument_editor/instrument_editor_ssg_form.cpp
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_ssg_form.cpp
@@ -57,7 +57,7 @@ bool isModulatedWaveformSSG(int type)
 }
 
 InstrumentEditorSSGForm::InstrumentEditorSSGForm(int num, QWidget *parent) :
-	QWidget(parent),
+	QDialog(parent),
 	ui(new Ui::InstrumentEditorSSGForm),
 	instNum_(num)
 {

--- a/BambooTracker/gui/instrument_editor/instrument_editor_ssg_form.hpp
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_ssg_form.hpp
@@ -26,7 +26,7 @@
 #ifndef INSTRUMENT_EDITOR_SSG_FORM_HPP
 #define INSTRUMENT_EDITOR_SSG_FORM_HPP
 
-#include <QWidget>
+#include <QDialog>
 #include <QKeyEvent>
 #include <memory>
 #include "bamboo_tracker.hpp"
@@ -41,7 +41,7 @@ namespace Ui {
 	class InstrumentEditorSSGForm;
 }
 
-class InstrumentEditorSSGForm : public QWidget
+class InstrumentEditorSSGForm : public QDialog
 {
 	Q_OBJECT
 

--- a/BambooTracker/gui/instrument_editor/instrument_editor_ssg_form.ui
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_ssg_form.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>InstrumentEditorSSGForm</class>
- <widget class="QWidget" name="InstrumentEditorSSGForm">
+ <widget class="QDialog" name="InstrumentEditorSSGForm">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -1415,13 +1415,13 @@ void MainWindow::openInstrumentEditor()
 	int num = item->data(Qt::UserRole).toInt();
 
 	if (!instForms_->getForm(num)) {	// Create form
-		std::shared_ptr<QWidget> form;
+		std::shared_ptr<QDialog> form;
 		auto inst = bt_->getInstrument(num);
 
 		switch (inst->getType()) {
 		case InstrumentType::FM:
 		{
-			auto fmForm = std::make_shared<InstrumentEditorFMForm>(num);
+			auto fmForm = std::make_shared<InstrumentEditorFMForm>(num, this);
 			form = fmForm;
 			fmForm->setCore(bt_);
 			fmForm->setConfiguration(config_.lock());
@@ -1470,7 +1470,7 @@ void MainWindow::openInstrumentEditor()
 		}
 		case InstrumentType::SSG:
 		{
-			auto ssgForm = std::make_shared<InstrumentEditorSSGForm>(num);
+			auto ssgForm = std::make_shared<InstrumentEditorSSGForm>(num, this);
 			form = ssgForm;
 			ssgForm->setCore(bt_);
 			ssgForm->setConfiguration(config_.lock());
@@ -1519,7 +1519,7 @@ void MainWindow::openInstrumentEditor()
 		}
 		case InstrumentType::ADPCM:
 		{
-			auto adpcmForm = std::make_shared<InstrumentEditorADPCMForm>(num);
+			auto adpcmForm = std::make_shared<InstrumentEditorADPCMForm>(num, this);
 			form = adpcmForm;
 			adpcmForm->setCore(bt_);
 			adpcmForm->setConfiguration(config_.lock());
@@ -1567,7 +1567,7 @@ void MainWindow::openInstrumentEditor()
 		}
 		case InstrumentType::Drumkit:
 		{
-			auto kitForm = std::make_shared<InstrumentEditorDrumkitForm>(num);
+			auto kitForm = std::make_shared<InstrumentEditorDrumkitForm>(num, this);
 			form = kitForm;
 			kitForm->setCore(bt_);
 			kitForm->setConfiguration(config_.lock());


### PR DESCRIPTION
This changes all instrument editor dialogs to QDialog subclasses parented to the main window. As a result, the dialogs remain on top of the main window and open centered within it. This matches FamiTracker and probably most user expectations (I know of myself and one other person who dislikes the current behavior).

It also causes instrument dialogs to share the parent's taskbar entry. Is it a good thing? FamiTracker does that (at least on Wine), and it should make it easier to distinguish which of 2 instrument dialogs belongs to each of 2 BambooTracker main windows (which I've been confused by in the past).

(If I don't switch to QDialog, but give the instrument editors parents anyway, the dialog window contents are plastered within the main window.)

Tested on Linux. Will test on Windows at some point.

## Questions

I'm not convinced `std::shared_ptr<QWidget/QDialog>` is a good idea (the QDialogs survive being closed and are only destroyed when you delete the instrument or open a new document), but it works out in practice, so it's OK I guess?

Should `InstrumentEditorFMForm`/etc. inheriting from QDialog be renamed to include "Dialog" in the names?