### PR TITLE
Switch GitHub Actions to Ubuntu 18.04 

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: Linux (Ubuntu 16.04)
+name: Linux (Ubuntu 18.04)
 
 on:
   push:
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Identify build type.


### PR DESCRIPTION
16.04 has been decommissioned: https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/