### PR TITLE
Fix VGM files being written with incorrect headers

### DIFF
--- a/BambooTracker/chip/register_write_logger.cpp
+++ b/BambooTracker/chip/register_write_logger.cpp
@@ -34,7 +34,8 @@ AbstractRegisterWriteLogger::AbstractRegisterWriteLogger(int target)
 	: target_(target),
 	  lastWait_(0),
 	  isSetLoop_(false),
-	  loopPoint_(0)
+	  loopPoint_(0),
+	  totalSampCnt_(0)
 {
 }
 


### PR DESCRIPTION
## Problem

`AbstractRegisterWriteLogger::totalSampCnt_` was not initialized to 0, causing `AbstractRegisterWriteLogger::getSampleLength()` to return the wrong value, and `BambooTracker::exportToVgm()` to write random incorrect loop/length headers to .vgm files.

(~~The lengths were not always incorrect, but seem to be more correct on Windows, and more random on Linux.~~ If anyone's interested I have a collection of various .vgm exports: [in-credits vgm length errors.zip](https://github.com/BambooTracker/BambooTracker/files/7633639/in-credits.vgm.length.errors.zip))

## Fix

This initializes `totalSampCnt_` to 0, making the .vgm headers deterministic (in my testing) and correct (I hope). I got identical files (including the same length/loop headers), when I exported a .vgm file right after opening a module, and when I clicked Export while the module was playing.

EDIT: I was told to install https://github.com/vgmrips/vgmtools and run `vgm_ptch -Check *.vgm` to identify incorrect length/loop headers. When I ran the command on the folder I zipped up above, it found that all files except `fixed1`, `fixed2`, and `in-credits.vgm` had incorrect length headers (ranging from off-by-one, to a few hundred, to blatantly incorrect), but none had incorrect loop points.