### PR TITLE
Share a global SliderStyle across all sliders and dialogs

### DIFF
--- a/BambooTracker/gui/configuration_dialog.cpp
+++ b/BambooTracker/gui/configuration_dialog.cpp
@@ -350,7 +350,7 @@ ConfigurationDialog::ConfigurationDialog(std::weak_ptr<Configuration> config, st
 	case 48000:	ui->sampleRateComboBox->setCurrentIndex(1);	break;
 	case 55466:	ui->sampleRateComboBox->setCurrentIndex(2);	break;
 	}
-	ui->bufferLengthHorizontalSlider->setStyle(new SliderStyle());
+	ui->bufferLengthHorizontalSlider->setStyle(SliderStyle::instance());
 	QObject::connect(ui->bufferLengthHorizontalSlider, &QSlider::valueChanged,
 					 this, [&](int value) {
 		ui->bufferLengthLabel->setText(QString::number(value) + "ms");

--- a/BambooTracker/gui/instrument_editor/instrument_editor_drumkit_form.cpp
+++ b/BambooTracker/gui/instrument_editor/instrument_editor_drumkit_form.cpp
@@ -90,7 +90,7 @@ InstrumentEditorDrumkitForm::InstrumentEditorDrumkitForm(int num, QWidget *paren
 					 this, [&] { emit sampleMemoryChanged(); });
 
 	//========== Pan ==========//
-	ui->panHorizontalSlider->setStyle(new SliderStyle);
+	ui->panHorizontalSlider->setStyle(SliderStyle::instance());
 	ui->panHorizontalSlider->installEventFilter(this);
 	ui->panPosLabel->setText(QCoreApplication::translate("Panning", PAN_TEXT[ui->panHorizontalSlider->value()]));
 }

--- a/BambooTracker/gui/labeled_horizontal_slider.cpp
+++ b/BambooTracker/gui/labeled_horizontal_slider.cpp
@@ -43,7 +43,7 @@ LabeledHorizontalSlider::LabeledHorizontalSlider(QString text, QString prefix, Q
 	prefix_ = prefix;
 	suffix_ = suffix;
 	updateValueLabel();
-	ui->slider->setStyle(new SliderStyle());
+	ui->slider->setStyle(SliderStyle::instance());
 	ui->slider->installEventFilter(this);
 }
 

--- a/BambooTracker/gui/labeled_vertical_slider.cpp
+++ b/BambooTracker/gui/labeled_vertical_slider.cpp
@@ -43,7 +43,7 @@ LabeledVerticalSlider::LabeledVerticalSlider(QString text, QString prefix, QStri
 	prefix_ = prefix;
 	suffix_ = suffix;
 	updateValueLabel();
-	ui->slider->setStyle(new SliderStyle());
+	ui->slider->setStyle(SliderStyle::instance());
 	ui->slider->installEventFilter(this);
 }
 

--- a/BambooTracker/gui/slider_style.cpp
+++ b/BambooTracker/gui/slider_style.cpp
@@ -25,6 +25,20 @@
 
 #include "slider_style.hpp"
 
+SliderStyle::SliderStyle(QStyle * style) :
+	QProxyStyle(style)
+{}
+
+static SliderStyle* SLIDER_STYLE = nullptr;
+
+SliderStyle* SliderStyle::instance()
+{
+	if (SLIDER_STYLE == nullptr) {
+		SLIDER_STYLE = new SliderStyle();
+	}
+	return SLIDER_STYLE;
+}
+
 int SliderStyle::styleHint (StyleHint hint, const QStyleOption* option,
 							const QWidget* widget, QStyleHintReturn* returnData) const
 {

--- a/BambooTracker/gui/slider_style.hpp
+++ b/BambooTracker/gui/slider_style.hpp
@@ -30,7 +30,14 @@
 
 class SliderStyle : public QProxyStyle
 {
+private:
+	SliderStyle(QStyle *style = nullptr);
+
 public:
+	/// Get a global SliderStyle that lasts for the lifetime of the app.
+	/// Can only be called a single thread (generally the main GUI thread).
+	static SliderStyle* instance();
+
 	virtual int styleHint (StyleHint hint, const QStyleOption* option = nullptr,
 						   const QWidget* widget = nullptr, QStyleHintReturn* returnData = nullptr) const;
 };


### PR DESCRIPTION
Previously, every dialog and every slider which snaps to the cursor created its own SliderStyle, and never destroyed it (and [`QWidget::setStyle()`](https://doc.qt.io/qt-5/qwidget.html#setStyle) does not transfer ownership). As a result, opening a few instrument dialogs can create a hundred SliderStyle objects, and opening >10 instrument dialogs can create over a thousand objects. Not only does this leak memory, but it triggers a bug in KDE's Breeze QStyle where creating many QProxyStyle at once slows down the program (https://bugs.kde.org/show_bug.cgi?id=450394).

This PR creates a single global SliderStyle initialized on first access, used by every QSlider with a SliderStyle. This fixes a memory leak when opening and closing instrument dialogs, and avoids triggering the Breeze bug.

Tested on M1 Mac, macOS 12.2.1, the program does not crash. Did not verify it fixes the leak, but it should work. I didn't test this code on other platforms though.

Fixes #418.