### PR TITLE
Raise macOS version of GHA to 11

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     steps:
       - name: Identify build type.
@@ -70,16 +70,16 @@ jobs:
       ## macOS-specific steps
 
       - name: Pin Xcode version
-        run: sudo xcode-select -s "/Applications/Xcode_12.1.1.app"
+        run: sudo xcode-select -s "/Applications/Xcode_13.2.1.app"
 
       - name: Installing dependencies.
         run: |
           export HOMEBREW_NO_INSTALL_CLEANUP=1
           brew update
-          # JACK implies brew link python-3.9, fails due to shipped python binaries
-          brew unlink python@3.9
-          brew link --overwrite python@3.9
-          brew upgrade --force python@3.9
+          # JACK implies brew link python-3.10, fails due to shipped python binaries
+          brew unlink python@3.10
+          brew link --overwrite python@3.10
+          brew upgrade --force python@3.10
           brew install qt@5 pkg-config jack coreutils
           brew link --force qt@5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - [#461] - Enhance font settings (thanks [@NEO-SPECTRUMAN])
+- [#463] - Raise macOS version of GitHub Actions workflow to 11
 
 ### Fixed
 
@@ -16,6 +17,7 @@
 
 [#460]: https://github.com/BambooTracker/BambooTracker/issues/460
 [#461]: https://github.com/BambooTracker/BambooTracker/issues/461
+[#463]: https://github.com/BambooTracker/BambooTracker/pull/463
 
 ## v0.5.2 (2022-08-24)
 


### PR DESCRIPTION
Due to [an annoucement from GitHub](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/), I changed macOS workflow of GitHub Actions to use macOS 11.
There were an error in Homebrew, so I changed the python version to 10, but I don't know if this will work correctly.