### PR TITLE
Update Qt6 to 6.4.0

### DIFF
--- a/.github/workflows/windows-10-qt6.yml
+++ b/.github/workflows/windows-10-qt6.yml
@@ -25,13 +25,13 @@ env:
   BUILD_TARGET: windows-10-64bit
   MAKE: mingw32-make
   BT_INSTALLBASE: ${{ github.workspace }}/target/
-  MINGW_VERSION: 8.1.0
+  MINGW_VERSION: 11.2.0
   MINGW_BITNESS: 64
   MINGW_CHOCOBASE: /c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64
   MINGW_INSTALLBASE: ${{ github.workspace }}/mingw64/
-  QT_VERSION: 6.1.1
-  QT_TOOLCHAIN: win64_mingw81
-  QT_MODULES: qtbase qttools qttranslations qt5compat
+  QT_VERSION: 6.4.0
+  QT_TOOLCHAIN: win64_mingw
+  QT_MODULES: qtbase qttools qttranslations qt5compat qtdeclarative
   QT_INSTALLBASE: ${{ github.workspace }}/Qt/
 
 jobs:


### PR DESCRIPTION
And the MinGW in that build to 11.2.0, according to https://wiki.qt.io/MinGW#Toolchains_used_in_Qt_binary_packages (idr where they publish required compiler versions).