### PR TITLE
Use Qt6 for macOS build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,6 +58,7 @@ environment:
       DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-windows-xp-32bit.zip
       MAKE: mingw32-make
       RELEASE_BUILD: true
+    # macOS Catalina
     - APPVEYOR_JOB_NAME: for macOS
       APPVEYOR_BUILD_WORKER_IMAGE: macos-catalina
       PLATFORM: macos
@@ -104,9 +105,9 @@ before_build:
 
       # Download failed: Homebrew-installed `curl` is not installed
       brew install curl
-      brew install qt@5 pkg-config jack p7zip
+      brew install pkg-config jack p7zip
 
-      export PATH="/usr/local/opt/qt@5/bin:$PATH"
+      export PATH="$HOME/Qt/6.4/macos/bin:$PATH"
       export PKG_CONFIG_PATH="/usr/local/opt/jack/lib/pkgconfig"${PKG_CONFIG_PATH:+':'}$PKG_CONFIG_PATH
 
 # to run your custom scripts instead of automatic MSBuild

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -80,8 +80,8 @@ jobs:
           brew unlink python@3.10
           brew link --overwrite python@3.10
           brew upgrade --force python@3.10
-          brew install qt@5 pkg-config jack coreutils
-          brew link --force qt@5
+          brew install qt@6 pkg-config jack coreutils
+          brew link --force qt@6
 
       ## End macOS-specific steps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fix visibility of FM 3,4ch when song mode is changed from expanded to standard (thanks TotO)
 - Run tick process when echo buffer is empty
 - Reset `0Qxy`, `0Rxy` note slide in the next note on (thanks Getsuka-P)
+- [#470] - Fix sliders not to move during editing unrelated slider ([#468], [#469]; thanks [@OPNA2608], [@cxong], [@Zexxerd])
 
 [#464]: https://github.com/BambooTracker/BambooTracker/pull/464
 [#386]: https://github.com/BambooTracker/BambooTracker/issues/386
@@ -38,6 +39,9 @@
 [#433]: https://github.com/BambooTracker/BambooTracker/issues/433
 [#434]: https://github.com/BambooTracker/BambooTracker/issues/434
 [#471]: https://github.com/BambooTracker/BambooTracker/pull/471
+[#470]: https://github.com/BambooTracker/BambooTracker/pull/470
+[#468]: https://github.com/BambooTracker/BambooTracker/issues/468
+[#469]: https://github.com/BambooTracker/BambooTracker/issues/469
 
 ## v0.5.3 (2022-09-18)
 


### PR DESCRIPTION
#468

Older versions of Qt seem to have a problem with QSlider not rendering properly with the recent Monterey update (<https://bugreports.qt.io/browse/QTBUG-98093>).

This is a PR to see if changing the dev build in Appveyor to use Qt6 solves this problem.
In some cases, the GHA release build recipe may also need to be modified.