### PR TITLE
Add PMB bank import

### DIFF
--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -106,6 +106,7 @@ SOURCES += \
     io/io_utils.cpp \
     io/opni_io.cpp \
     io/p86_io.cpp \
+    io/pmb_io.cpp \
     io/ppc_io.cpp \
     io/pps_io.cpp \
     io/pvi_io.cpp \
@@ -305,6 +306,7 @@ HEADERS += \
     io/io_utils.hpp \
     io/opni_io.hpp \
     io/p86_io.hpp \
+    io/pmb_io.hpp \
     io/ppc_io.hpp \
     io/pps_io.hpp \
     io/pvi_io.hpp \

--- a/BambooTracker/CMakeLists.txt
+++ b/BambooTracker/CMakeLists.txt
@@ -196,6 +196,7 @@ set (BT_SOURCES
 	io/module_io.cpp
 	io/opni_io.cpp
 	io/p86_io.cpp
+	io/pmb_io.cpp
 	io/ppc_io.cpp
 	io/pps_io.cpp
 	io/pvi_io.cpp

--- a/BambooTracker/instrument/bank.cpp
+++ b/BambooTracker/instrument/bank.cpp
@@ -35,6 +35,7 @@
 #include "io/pvi_io.hpp"
 #include "io/pzi_io.hpp"
 #include "io/dat_io.hpp"
+#include "io/pmb_io.hpp"
 #include "format/wopn_file.h"
 
 BtBank::BtBank(const std::vector<int>& ids, const std::vector<std::string>& names)
@@ -332,6 +333,37 @@ AbstractInstrument* Mucom88Bank::loadInstrument(size_t index, std::weak_ptr<Inst
 }
 
 void Mucom88Bank::setInstrumentName(size_t index, const std::string& name)
+{
+	names_.at(index) = name;
+}
+
+/******************************/
+PmbBank::PmbBank(const std::vector<int>& ids, const std::vector<std::string>& names, const std::vector<std::vector<uint8_t>>& samples)
+	: ids_(ids), names_(names), samples_(samples)
+{
+}
+
+size_t PmbBank::getNumInstruments() const
+{
+	return ids_.size();
+}
+
+std::string PmbBank::getInstrumentIdentifier(size_t index) const
+{
+	return std::to_string(ids_.at(index));
+}
+
+std::string PmbBank::getInstrumentName(size_t index) const
+{
+	return names_.at(index);
+}
+
+AbstractInstrument* PmbBank::loadInstrument(size_t index, std::weak_ptr<InstrumentsManager> instMan, int instNum) const
+{
+	return io::PmbIO::loadInstrument(samples_.at(index), names_.at(index), instMan, instNum);
+}
+
+void PmbBank::setInstrumentName(size_t index, const std::string& name)
 {
 	names_.at(index) = name;
 }

--- a/BambooTracker/instrument/bank.hpp
+++ b/BambooTracker/instrument/bank.hpp
@@ -199,3 +199,22 @@ private:
 	std::vector<std::string> names_;
 	std::vector<io::BinaryContainer> instCtrs_;
 };
+
+class PmbBank final : public AbstractBank
+{
+public:
+	PmbBank(const std::vector<int>& ids, const std::vector<std::string>& names,
+			const std::vector<std::vector<uint8_t>>& samples);
+
+	size_t getNumInstruments() const override;
+	std::string getInstrumentIdentifier(size_t index) const override;
+	std::string getInstrumentName(size_t) const override;
+	AbstractInstrument* loadInstrument(size_t index, std::weak_ptr<InstrumentsManager> instMan, int instNum) const override;
+
+	void setInstrumentName(size_t index, const std::string& name);
+
+private:
+	std::vector<int> ids_;
+	std::vector<std::string> names_;
+	std::vector<std::vector<uint8_t>> samples_;
+};

--- a/BambooTracker/io/bank_io.cpp
+++ b/BambooTracker/io/bank_io.cpp
@@ -35,6 +35,7 @@
 #include "pvi_io.hpp"
 #include "pzi_io.hpp"
 #include "dat_io.hpp"
+#include "pmb_io.hpp"
 
 namespace io
 {
@@ -68,6 +69,7 @@ BankIO::BankIO()
 	handler_.add(new PviIO);
 	handler_.add(new PziIO);
 	handler_.add(new DatIO);
+	handler_.add(new PmbIO);
 }
 
 BankIO& BankIO::getInstance()

--- a/BambooTracker/io/pmb_io.cpp
+++ b/BambooTracker/io/pmb_io.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2022 Rerrah
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "pmb_io.hpp"
+#include <vector>
+#include <limits>
+#include "instrument.hpp"
+#include "file_io_error.hpp"
+#include "chip/codec/ymb_codec.hpp"
+
+namespace io
+{
+PmbIO::PmbIO() : AbstractBankIO("pmb", "FM Towns PMB", true, false) {}
+
+AbstractBank* PmbIO::load(const BinaryContainer& ctr) const
+{
+	/* no identifier & weird header inconsistencies across samples, just don't bother with the header */
+	constexpr size_t HEADER_SIZE = 0x1008;
+	if (ctr.size() < HEADER_SIZE) throw FileCorruptionError(FileType::Bank, 0);
+
+	std::vector<int> ids;
+	std::vector<std::string> names;
+	std::vector<std::vector<uint8_t>> samples;
+	size_t globCsr = HEADER_SIZE;
+	constexpr int MAX_CNT = 32;
+	for (int i = 0; i < MAX_CNT; ++i) {
+		// cannot determine how many samples there will be, just stop when we've reached EOF
+		if (globCsr == ctr.size()) break;
+		std::string name = ctr.readString(globCsr, 8);
+		globCsr += 8;
+		// ignore sample ID, they may override each other or disagree with the ones in the header
+		// uint32_t id = ctr.readUint32(globCsr);
+		globCsr += 4;
+		uint32_t len = ctr.readUint32(globCsr);
+		globCsr += 4;
+
+		// unknown data
+		globCsr += 16;
+
+		ids.push_back(i);
+		names.push_back(name);
+
+		std::vector<uint8_t>&& smp = ctr.getSubcontainer(globCsr, len).toVector();
+
+		std::vector<int16_t> buf(smp.size());
+		std::transform(smp.begin(), smp.end(), buf.begin(), [globCsr](uint8_t v) {
+			// first convert from RF5C68 encoding to more regular unsigned 8-bit
+			// summarised from the datasheet:
+			//        0x00 -> 0x80 (not mentioned in datasheet but seems to work like this in banks)
+			// 0x01 - 0x7F -> 0x7F - 0x01
+			// 0x80 - 0xFE -> 0x80 - 0xFE (unchanged)
+			//        0xFF -> trigger for jumping into loop. unsure if occurs in PMB banks, loops not handled by us anyway. error if encountered
+			if (v == 0xFF) throw FileCorruptionError (FileType::Bank, globCsr);
+			uint8_t regular = (v < 0x80) ? (0x80 - v) : v;
+
+			// now convert this into the format ADPCM conversion requires
+			uint16_t grown = static_cast<uint16_t>(regular + 0x80) << 8;
+			return *(reinterpret_cast<int16_t *> (&grown));
+		});
+		smp.resize((smp.size() + 1) / 2);
+		smp.shrink_to_fit();
+		smp.back() = 0;	// Clear last data
+		codec::ymb_encode(buf.data(), smp.data(), buf.size());
+		samples.push_back(std::move(smp));
+		globCsr += len;
+	}
+
+	return new PmbBank(ids, names, samples);
+}
+
+AbstractInstrument* PmbIO::loadInstrument(const std::vector<uint8_t>& sample,
+											std::string name,
+										  std::weak_ptr<InstrumentsManager> instMan,
+										  int instNum)
+{
+	std::shared_ptr<InstrumentsManager> instManLocked = instMan.lock();
+	int sampIdx = instManLocked->findFirstAssignableSampleADPCM();
+	if (sampIdx < 0) throw FileCorruptionError(FileType::Bank, 0);
+
+	InstrumentADPCM* adpcm = new InstrumentADPCM(instNum, name, instManLocked.get());
+	adpcm->setSampleNumber(sampIdx);
+
+	instManLocked->storeSampleADPCMRawSample(sampIdx, sample);
+	instManLocked->setSampleADPCMRootKeyNumber(sampIdx, 67);	// o5g
+	instManLocked->setSampleADPCMRootDeltaN(sampIdx, 0x49cd); // 16000Hz
+
+	return adpcm;
+}
+}

--- a/BambooTracker/io/pmb_io.hpp
+++ b/BambooTracker/io/pmb_io.hpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Rerrah
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include "bank_io.hpp"
+
+namespace io
+{
+class PmbIO final : public AbstractBankIO
+{
+public:
+	PmbIO();
+	AbstractBank* load(const BinaryContainer& ctr) const override;
+
+	static AbstractInstrument* loadInstrument(const std::vector<uint8_t>& sample,
+												std::string name,
+											  std::weak_ptr<InstrumentsManager> instMan,
+											  int instNum);
+};
+}


### PR DESCRIPTION
This is a bank format used on the FM Towns. I still have many uncertainties about the bank metadata, but the sample data itself is easy to support.

The FM Towns isn't my particular forte but I know of 2 games & sound drivers that use PMB banks:
- Xenon (PMD): [xenon.pmb](https://github.com/BambooTracker/BambooTracker/files/10217389/xenon.pmb.zip)
- Desire ("KML/DOFMD"): [Desire's pmbs](https://github.com/BambooTracker/BambooTracker/files/10219945/Desire_pmbs.zip)


~~I still wish to check this against Desire's 3 PMB banks before finalising the PR, but I'm not on my PC with the required files & disc dumps right now.~~
Checked them now, work fine. I'll give the sample conversion another look cuz I just understood more about the format used, but should be ready otherwise.