### PR TITLE
Add VGM export level configuration

### DIFF
--- a/BambooTracker/bamboo_tracker.hpp
+++ b/BambooTracker/bamboo_tracker.hpp
@@ -352,7 +352,7 @@ public:
 	using ExportCancellCallback = std::function<bool()>;
 	bool exportToWav(io::WavContainer& container, int loopCnt, ExportCancellCallback checkFunc);
 	bool exportToVgm(io::BinaryContainer& container, int target, bool gd3TagEnabled,
-					 const io::GD3Tag& tag, ExportCancellCallback checkFunc);
+					 const io::GD3Tag& tag, bool shouldSetMix, double gain, ExportCancellCallback checkFunc);
 	bool exportToS98(io::BinaryContainer& container, int target, bool tagEnabled,
 					 const io::S98Tag& tag, int rate, ExportCancellCallback checkFunc);
 

--- a/BambooTracker/chip/opna.cpp
+++ b/BambooTracker/chip/opna.cpp
@@ -72,6 +72,8 @@ OPNA::OPNA(OpnaEmulator emu, int clock, int rate, size_t maxDuration, size_t dra
 	: Chip(count_++, clock, rate, DEFAULT_AUTO_RATE, maxDuration,
 		   std::move(fmResampler), std::move(ssgResampler),
 		   logger),
+	  volumeFm_(0),
+	  volumeSsg_(0),
 	  dramSize_(dramSize),
 	  rcIntf_(std::make_unique<SimpleRealChipInterface>()),
 	  isForcedRegWrite_(false),
@@ -198,6 +200,7 @@ uint8_t OPNA::getRegister(uint32_t offset) const
 void OPNA::setVolumeFM(double dB)
 {
 	std::lock_guard<std::mutex> lg(mutex_);
+	volumeFm_ = dB;
 	busVolumeRatio_[FM] = std::pow(10.0, (dB - VOL_REDUC_) / 20.0);
 	updateVolumeRatio(FM);
 }
@@ -205,6 +208,7 @@ void OPNA::setVolumeFM(double dB)
 void OPNA::setVolumeSSG(double dB)
 {
 	std::lock_guard<std::mutex> lg(mutex_);
+	volumeSsg_ = dB;
 	busVolumeRatio_[SSG] = std::pow(10.0, (dB - VOL_REDUC_) / 20.0);
 	updateVolumeRatio(SSG);
 

--- a/BambooTracker/chip/opna.hpp
+++ b/BambooTracker/chip/opna.hpp
@@ -60,7 +60,9 @@ public:
 	void setRegister(uint32_t offset, uint8_t value) override;
 	uint8_t getRegister(uint32_t offset) const override;
 	void setVolumeFM(double dB);
+	double getVolumeFM() const noexcept { return volumeFm_; }
 	void setVolumeSSG(double dB);
+	double getVolumeSSG() const noexcept { return volumeSsg_; }
 	size_t getDRAMSize() const noexcept;
 	void mix(int16_t* stream, size_t nSamples) override;
 
@@ -75,6 +77,7 @@ private:
 	static size_t count_;
 
 	std::unique_ptr<Ym2608Interface> intf_;
+	double volumeFm_, volumeSsg_;
 	size_t dramSize_;
 
 	std::unique_ptr<SimpleRealChipInterface> rcIntf_;

--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -3582,7 +3582,7 @@ void MainWindow::on_actionVGM_triggered()
 		QByteArray bytes;
 		{
 			io::BinaryContainer container;
-			if (!bt_->exportToVgm(container, dialog.getExportTarget(), dialog.enabledGD3(), tag, bar))
+			if (!bt_->exportToVgm(container, dialog.getExportTarget(), dialog.enabledGD3(), tag, dialog.isEnabledMix(), dialog.getGain(), bar))
 				goto AFTER_VGM_WRITE;	// Jump if cancelled
 			bytes.reserve(container.size());
 			std::move(container.begin(), container.end(), std::back_inserter(bytes));

--- a/BambooTracker/gui/vgm_export_settings_dialog.cpp
+++ b/BambooTracker/gui/vgm_export_settings_dialog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Rerrah
+ * Copyright (C) 2018-2022 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -224,6 +224,16 @@ int VgmExportSettingsDialog::getExportTarget() const
 		target |= io::Export_YM2149Psg;
 
 	return target;
+}
+
+bool VgmExportSettingsDialog::isEnabledMix() const
+{
+	return ui->mixGroupBox->isChecked();
+}
+
+double VgmExportSettingsDialog::getGain() const
+{
+	return ui->gainDoubleSpinBox->value();
 }
 
 void VgmExportSettingsDialog::updateSupportInformation()

--- a/BambooTracker/gui/vgm_export_settings_dialog.hpp
+++ b/BambooTracker/gui/vgm_export_settings_dialog.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Rerrah
+ * Copyright (C) 2018-2022 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -56,6 +56,8 @@ public:
 	QString getNotes() const;
 	io::GD3Tag getGD3Tag() const;
 	int getExportTarget() const;
+	bool isEnabledMix() const;
+	double getGain() const;
 
 private slots:
 	void updateSupportInformation();

--- a/BambooTracker/gui/vgm_export_settings_dialog.ui
+++ b/BambooTracker/gui/vgm_export_settings_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>507</width>
-    <height>654</height>
+    <height>685</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -418,6 +418,53 @@
            <property name="text">
             <string>YM2149 PSG</string>
            </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="mixGroupBox">
+           <property name="title">
+            <string>Mix</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+           <layout class="QFormLayout" name="formLayout_2">
+            <item row="0" column="0">
+             <widget class="QLabel" name="gainLabel">
+              <property name="text">
+               <string>Gain</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QDoubleSpinBox" name="gainDoubleSpinBox">
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="suffix">
+               <string notr="true">dB</string>
+              </property>
+              <property name="decimals">
+               <number>1</number>
+              </property>
+              <property name="minimum">
+               <double>-10.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>10.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="value">
+               <double>-1.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
          <item>

--- a/BambooTracker/io/export_io.hpp
+++ b/BambooTracker/io/export_io.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Rerrah
+ * Copyright (C) 2019-2022 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,6 +27,8 @@
 
 #include <vector>
 #include <string>
+#include <cmath>
+#include <cstdint>
 
 namespace io
 {
@@ -44,9 +46,20 @@ struct GD3Tag
 	std::string notes;
 };
 
+/**
+ * @brief Helper struct of SSG volume level for VGM export.
+ */
+struct VgmMix
+{
+	const uint16_t ssgMultiplier;
+
+	VgmMix(double fmLevel, double ssgLevel, double gain)
+		: ssgMultiplier(static_cast<uint16_t>(std::pow(10.0, (ssgLevel + gain - fmLevel) / 20.0) * 0x100) | 0x8000) {}
+};
+
 void writeVgm(BinaryContainer& container, int target, const std::vector<uint8_t>& samples,
 			  uint32_t clock, uint32_t rate, bool loopFlag, uint32_t loopPoint,
-			  uint32_t loopSamples, uint32_t totalSamples, bool gd3TagEnabled, const GD3Tag& tag);
+			  uint32_t loopSamples, uint32_t totalSamples, const GD3Tag* tag, const VgmMix* mix);
 
 // S98 ----------
 struct S98Tag

--- a/BambooTracker/opna_controller.cpp
+++ b/BambooTracker/opna_controller.cpp
@@ -1011,6 +1011,11 @@ void OPNAController::setMasterVolumeFM(double dB)
 	opna_->setVolumeFM(dB);
 }
 
+double OPNAController::getMasterVolumeFM() const
+{
+	return opna_->getVolumeFM();
+}
+
 /********** Set effect **********/
 void OPNAController::setPanFM(int ch, int value)
 {
@@ -2256,6 +2261,11 @@ void OPNAController::setRealVolumeSSG(SSGChannel& ssg)
 void OPNAController::setMasterVolumeSSG(double dB)
 {
 	opna_->setVolumeSSG(dB);
+}
+
+double OPNAController::getMasterVolumeSSG() const
+{
+	return opna_->getVolumeSSG();
 }
 
 /********** Set effect **********/

--- a/BambooTracker/opna_controller.hpp
+++ b/BambooTracker/opna_controller.hpp
@@ -137,6 +137,7 @@ public:
 	void setVolumeFM(int ch, int volume);
 	void setOneshotVolumeFM(int ch, int volume);
 	void setMasterVolumeFM(double dB);
+	double getMasterVolumeFM() const;
 
 	// Set effect
 	void setPanFM(int ch, int value);
@@ -264,6 +265,7 @@ public:
 	void setVolumeSSG(int ch, int volume);
 	void setOneshotVolumeSSG(int ch, int volume);
 	void setMasterVolumeSSG(double dB);
+	double getMasterVolumeSSG() const;
 
 	// Set effect
 	void setArpeggioEffectSSG(int ch, int second, int third);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add wait-write mode
 - [#433] - Add key cut note (thanks [@wildmatsu])
 - [#471] - Support FM Towns .pmb file import (thanks [@OPNA2608])
+- [#472] - Add SSG mixing level configuration for VGM export ([#436]; thanks [@ValleyBell], [@nyanpasu64])
 
 ### Changed
 
@@ -42,6 +43,8 @@
 [#470]: https://github.com/BambooTracker/BambooTracker/pull/470
 [#468]: https://github.com/BambooTracker/BambooTracker/issues/468
 [#469]: https://github.com/BambooTracker/BambooTracker/issues/469
+[#472]: https://github.com/BambooTracker/BambooTracker/pull/472
+[#436]: https://github.com/BambooTracker/BambooTracker/issues/436
 
 ## v0.5.3 (2022-09-18)
 


### PR DESCRIPTION
Feature mentioned in #436.

The VGM export settings dialog now allows the user to select whether to write the setting of SSG volume level in the extra header.
Also, you can customize the volume level offset.

I don't know if my calculation is wrong, but it seems that if I set the offset to -1.0 dB, the volume will be the same as the BambooTracker's output. I'll check it out more...