### PR TITLE
Use Ubuntu 20.04 GHA runner image

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Identify build type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - `0Sxx`: Note release
   - `ESxx`: Note cut
 - [#433] - Enable to use `ESxx` in SSG, RSS, ADPCM channels (thanks [@wildmatsu])
+- [#473] - Use Ubuntu 20.04 GHA runner image
 
 ### Fixed
 
@@ -45,6 +46,7 @@
 [#469]: https://github.com/BambooTracker/BambooTracker/issues/469
 [#472]: https://github.com/BambooTracker/BambooTracker/pull/472
 [#436]: https://github.com/BambooTracker/BambooTracker/issues/436
+[#473]: https://github.com/BambooTracker/BambooTracker/pull/473
 
 ## v0.5.3 (2022-09-18)
 


### PR DESCRIPTION
actions/runner-images#6002

Ubuntu 18.04 no longer works in GHA, should upgrade it to 20.04.