### PR TITLE
Support partial repeat on ADPCM

### DIFF
--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -75,6 +75,7 @@ SOURCES += \
     gui/go_to_dialog.cpp \
     gui/gui_utils.cpp \
     gui/hide_tracks_dialog.cpp \
+    gui/instrument_editor/adpcm_address_spin_box.cpp \
     gui/instrument_editor/adpcm_drumkit_editor.cpp \
     gui/instrument_editor/adpcm_instrument_editor.cpp \
     gui/instrument_editor/adpcm_sample_editor.cpp \
@@ -267,6 +268,7 @@ HEADERS += \
     gui/go_to_dialog.hpp \
     gui/gui_utils.hpp \
     gui/hide_tracks_dialog.hpp \
+    gui/instrument_editor/adpcm_address_spin_box.hpp \
     gui/instrument_editor/adpcm_drumkit_editor.hpp \
     gui/instrument_editor/adpcm_instrument_editor.hpp \
     gui/instrument_editor/adpcm_sample_editor.hpp \
@@ -295,6 +297,7 @@ HEADERS += \
     gui/wheel_spin_box.hpp \
     instrument/instrument_property_defs.hpp \
     instrument/sample_adpcm.hpp \
+    instrument/sample_repeat.hpp \
     instrument/sequence_property.hpp \
     io/btb_io.hpp \
     io/bti_io.hpp \

--- a/BambooTracker/CMakeLists.txt
+++ b/BambooTracker/CMakeLists.txt
@@ -137,6 +137,7 @@ set (BT_SOURCES
 	gui/groove_settings_dialog.cpp
 	gui/gui_utils.cpp
 	gui/hide_tracks_dialog.cpp
+	gui/instrument_editor/adpcm_address_spin_box.cpp
 	gui/instrument_editor/adpcm_drumkit_editor.cpp
 	gui/instrument_editor/adpcm_instrument_editor.cpp
 	gui/instrument_editor/adpcm_sample_editor.cpp

--- a/BambooTracker/bamboo_tracker.cpp
+++ b/BambooTracker/bamboo_tracker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Rerrah
+ * Copyright (C) 2018-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -877,6 +877,16 @@ void BambooTracker::setSampleADPCMRepeatEnabled(int sampNum, bool enabled)
 bool BambooTracker::getSampleADPCMRepeatEnabled(int sampNum) const
 {
 	return instMan_->isSampleADPCMRepeatable(sampNum);
+}
+
+bool BambooTracker::setSampleADPCMRepeatRange(int sampNum, const SampleRepeatRange& range)
+{
+	return instMan_->setSampleADPCMRepeatrange(sampNum, range);
+}
+
+SampleRepeatRange BambooTracker::getSampleADPCMRepeatRange(int sampNum) const
+{
+	return instMan_->getSampleADPCMRepeatRange(sampNum);
 }
 
 void BambooTracker::storeSampleADPCMRawSample(int sampNum, const std::vector<uint8_t>& sample)

--- a/BambooTracker/bamboo_tracker.hpp
+++ b/BambooTracker/bamboo_tracker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Rerrah
+ * Copyright (C) 2018-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -35,6 +35,7 @@
 #include <array>
 #include "jamming.hpp"
 #include "instrument.hpp"
+#include "instrument/sample_repeat.hpp"
 #include "module.hpp"
 #include "command/command_manager.hpp"
 #include "chip/real_chip_interface.hpp"
@@ -50,6 +51,7 @@ class AbstractBank;
 class OPNAController;
 class PlaybackManager;
 class TickCounter;
+class SampleRepeatRange;
 
 class BambooTracker
 {
@@ -231,6 +233,8 @@ public:
 	int getSampleADPCMRootDeltaN(int sampNum) const;
 	void setSampleADPCMRepeatEnabled(int sampNum, bool enabled);
 	bool getSampleADPCMRepeatEnabled(int sampNum) const;
+	bool setSampleADPCMRepeatRange(int sampNum, const SampleRepeatRange& range);
+	SampleRepeatRange getSampleADPCMRepeatRange(int sampNum) const;
 	void storeSampleADPCMRawSample(int sampNum, const std::vector<uint8_t>& sample);
 	void storeSampleADPCMRawSample(int sampNum, std::vector<uint8_t>&& sample);
 	std::vector<uint8_t> getSampleADPCMRawSample(int sampNum) const;

--- a/BambooTracker/gui/color_palette.cpp
+++ b/BambooTracker/gui/color_palette.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Rerrah
+ * Copyright (C) 2018-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -71,6 +71,8 @@ ColorPalette::ColorPalette()
 	instADPCMSampViewGridColor = QColor::fromRgb(63, 63, 63, 170);
 	instADPCMSampViewDrawColor = QColor::fromRgb(255, 0, 0, 255);
 	instADPCMSampViewDirectDrawColor = QColor::fromRgb(255, 150, 0, 255);
+	instADPCMSampViewRepeatBeginColor = QColor::fromRgb(204, 102, 255, 255);
+	instADPCMSampViewRepeatEndColor = QColor::fromRgb(137, 167, 255, 255);
 
 	// Tone/Noise editor
 	tnToneCellColor = QColor::fromRgb(225, 209, 47, 255);

--- a/BambooTracker/gui/color_palette.hpp
+++ b/BambooTracker/gui/color_palette.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Rerrah
+ * Copyright (C) 2018-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -58,6 +58,7 @@ public:
 	QColor instADPCMMemAllColor, instADPCMMemCurColor, instADPCMMemBackColor;
 	QColor instADPCMSampViewForeColor, instADPCMSampViewBackColor, instADPCMSampViewCenterColor;
 	QColor instADPCMSampViewGridColor, instADPCMSampViewDrawColor, instADPCMSampViewDirectDrawColor;
+	QColor instADPCMSampViewRepeatBeginColor, instADPCMSampViewRepeatEndColor;
 
 	// Tone/Noise editor
 	QColor tnToneCellColor, tnToneTextColor;

--- a/BambooTracker/gui/instrument_editor/adpcm_address_spin_box.cpp
+++ b/BambooTracker/gui/instrument_editor/adpcm_address_spin_box.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2023 Rerrah
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "adpcm_address_spin_box.hpp"
+#include <QIntValidator>
+
+namespace
+{
+constexpr int ADDR_SHIFT = 5;
+}
+
+namespace
+{
+namespace start
+{
+constexpr int addressToPosition(int a)
+{
+	return a << (ADDR_SHIFT + 1);
+}
+
+constexpr int bytesToPosition(int b)
+{
+	return addressToPosition(b >> ADDR_SHIFT);
+}
+
+constexpr int positionToAddress(int p)
+{
+	return p >> (ADDR_SHIFT + 1);
+}
+}
+
+class StartAddressValidator : public QIntValidator
+{
+public:
+	StartAddressValidator(int bottom, int top, QObject *parent = nullptr) : QIntValidator(bottom, top, parent) {}
+	QValidator::State validate(QString& input, int& pos) const override
+	{
+		auto state = QIntValidator::validate(input, pos);
+		if (state == QIntValidator::Invalid) {
+			return QValidator::Invalid;
+		}
+
+		return !(input.toInt() % (1 << (ADDR_SHIFT + 1))) ? QValidator::Acceptable : QValidator::Intermediate;
+	}
+};
+}
+
+AdpcmStartAddressSpinBox::AdpcmStartAddressSpinBox(QWidget* parent)
+	: QSpinBox(parent)
+{
+	setSingleStep(1 << (ADDR_SHIFT + 1));
+	setMinimum(start::addressToPosition(0));
+	setValue(minimum());
+	setMaximum(minimum());
+}
+
+int AdpcmStartAddressSpinBox::valueByAddress() const
+{
+	return start::positionToAddress(value());
+}
+
+void AdpcmStartAddressSpinBox::setValueByAddress(int a)
+{
+	setValue(start::addressToPosition(a));
+}
+
+void AdpcmStartAddressSpinBox::setValueByBytes(int b)
+{
+	setValue(start::bytesToPosition(b));
+}
+
+void AdpcmStartAddressSpinBox::setMaximumByBytes(int b)
+{
+	setMaximum(start::bytesToPosition(b));
+}
+
+QValidator::State AdpcmStartAddressSpinBox::validate(QString& text, int& pos) const
+{
+	return StartAddressValidator(minimum(), maximum()).validate(text, pos);
+}
+
+namespace
+{
+namespace stop
+{
+constexpr int addressToPosition(int a)
+{
+	// (((a << ADDR_SHIFT) & 31) << 1) + 1
+	return (a << (ADDR_SHIFT + 1)) + 63;
+}
+
+constexpr int bytesToPosition(int b)
+{
+	return addressToPosition(b >> ADDR_SHIFT);
+}
+
+constexpr int positionToAddress(int p)
+{
+	return p >> (ADDR_SHIFT + 1);
+}
+}
+
+class StopAddressValidator : public QIntValidator
+{
+public:
+	StopAddressValidator(int bottom, int top, QObject *parent = nullptr) : QIntValidator(bottom, top, parent) {}
+	QValidator::State validate(QString& input, int& pos) const override
+	{
+		auto state = QIntValidator::validate(input, pos);
+		if (state == QIntValidator::Invalid) {
+			return QValidator::Invalid;
+		}
+
+		return !((input.toInt() + 1) % (1 << (ADDR_SHIFT + 1))) ? QValidator::Acceptable : QValidator::Intermediate;
+	}
+};
+}
+
+AdpcmStopAddressSpinBox::AdpcmStopAddressSpinBox(QWidget* parent)
+	: QSpinBox(parent)
+{
+	setSingleStep(1 << (ADDR_SHIFT + 1));
+	setMinimum(stop::addressToPosition(0));
+	setValue(minimum());
+	setMaximum(minimum());
+}
+
+int AdpcmStopAddressSpinBox::valueByAddress() const
+{
+	return stop::positionToAddress(value());
+}
+
+void AdpcmStopAddressSpinBox::setValueByAddress(int a)
+{
+	setValue(stop::addressToPosition(a));
+}
+
+void AdpcmStopAddressSpinBox::setValueByBytes(int b)
+{
+	setValue(stop::bytesToPosition(b));
+}
+
+void AdpcmStopAddressSpinBox::setMaximumByBytes(int b)
+{
+	setMaximum(stop::bytesToPosition(b));
+}
+
+QValidator::State AdpcmStopAddressSpinBox::validate(QString& text, int& pos) const
+{
+	return StopAddressValidator(minimum(), maximum()).validate(text, pos);
+}

--- a/BambooTracker/gui/instrument_editor/adpcm_address_spin_box.hpp
+++ b/BambooTracker/gui/instrument_editor/adpcm_address_spin_box.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 Rerrah
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <QSpinBox>
+
+class AdpcmStartAddressSpinBox : public QSpinBox
+{
+public:
+	AdpcmStartAddressSpinBox(QWidget* parent = nullptr);
+	int valueByAddress() const;
+	void setValueByAddress(int a);
+	void setValueByBytes(int b);
+	void setMaximumByBytes(int b);
+
+protected:
+	QValidator::State validate(QString& text, int& pos) const override;
+};
+
+class AdpcmStopAddressSpinBox : public QSpinBox
+{
+public:
+	AdpcmStopAddressSpinBox(QWidget* parent = nullptr);
+	int valueByAddress() const;
+	void setValueByAddress(int a);
+	void setValueByBytes(int b);
+	void setMaximumByBytes(int b);
+
+protected:
+	QValidator::State validate(QString& text, int& pos) const override;
+};
+

--- a/BambooTracker/gui/instrument_editor/adpcm_drumkit_editor.cpp
+++ b/BambooTracker/gui/instrument_editor/adpcm_drumkit_editor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Rerrah
+ * Copyright (C) 2020-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -269,9 +269,13 @@ void AdpcmDrumkitEditor::setInstrumentSampleParameters(int key)
 	if (instKit->getSampleEnabled(key)) {
 		int sampNum = instKit->getSampleNumber(key);
 		ui->sampleEditor->setInstrumentSampleParameters(
-					sampNum, instKit->isSampleRepeatable(key),
-					instKit->getSampleRootKeyNumber(key), instKit->getSampleRootDeltaN(key),
-					instKit->getSampleStartAddress(key), instKit->getSampleStopAddress(key),
+					sampNum,
+					instKit->isSampleRepeatable(key),
+					instKit->getSampleRepeatRange(key),
+					instKit->getSampleRootKeyNumber(key),
+					instKit->getSampleRootDeltaN(key),
+					instKit->getSampleStartAddress(key),
+					instKit->getSampleStopAddress(key),
 					instKit->getRawSample(key));
 		item->setText(1, QString::number(sampNum));
 		item->setText(2, QString::number(instKit->getPitch(key)));
@@ -279,7 +283,9 @@ void AdpcmDrumkitEditor::setInstrumentSampleParameters(int key)
 	}
 	else {
 		ui->sampleEditor->setInstrumentSampleParameters(
-					0, bt_.lock()->getSampleADPCMRepeatEnabled(0),
+					0,
+					bt_.lock()->getSampleADPCMRepeatEnabled(0),
+					bt_.lock()->getSampleADPCMRepeatRange(0),
 					bt_.lock()->getSampleADPCMRootKeyNumber(0),
 					bt_.lock()->getSampleADPCMRootDeltaN(0),
 					bt_.lock()->getSampleADPCMStartAddress(0),
@@ -334,7 +340,9 @@ void AdpcmDrumkitEditor::on_sampleGroupBox_clicked(bool checked)
 	else {
 		// Clear parameters
 		ui->sampleEditor->setInstrumentSampleParameters(
-					0, bt_.lock()->getSampleADPCMRepeatEnabled(0),
+					0,
+					bt_.lock()->getSampleADPCMRepeatEnabled(0),
+					bt_.lock()->getSampleADPCMRepeatRange(0),
 					bt_.lock()->getSampleADPCMRootKeyNumber(0),
 					bt_.lock()->getSampleADPCMRootDeltaN(0),
 					bt_.lock()->getSampleADPCMStartAddress(0),

--- a/BambooTracker/gui/instrument_editor/adpcm_instrument_editor.cpp
+++ b/BambooTracker/gui/instrument_editor/adpcm_instrument_editor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Rerrah
+ * Copyright (C) 2020-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -459,9 +459,13 @@ void AdpcmInstrumentEditor::setInstrumentSampleParameters()
 	auto instADPCM = dynamic_cast<InstrumentADPCM*>(inst.get());
 
 	ui->sampleEditor->setInstrumentSampleParameters(
-				instADPCM->getSampleNumber(), instADPCM->isSampleRepeatable(),
-				instADPCM->getSampleRootKeyNumber(), instADPCM->getSampleRootDeltaN(),
-				instADPCM->getSampleStartAddress(), instADPCM->getSampleStopAddress(),
+				instADPCM->getSampleNumber(),
+				instADPCM->isSampleRepeatable(),
+				instADPCM->getSampleRepeatRange(),
+				instADPCM->getSampleRootKeyNumber(),
+				instADPCM->getSampleRootDeltaN(),
+				instADPCM->getSampleStartAddress(),
+				instADPCM->getSampleStopAddress(),
 				instADPCM->getRawSample());
 }
 

--- a/BambooTracker/gui/instrument_editor/adpcm_sample_editor.hpp
+++ b/BambooTracker/gui/instrument_editor/adpcm_sample_editor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Rerrah
+ * Copyright (C) 2020-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -37,6 +37,7 @@
 #include <QPoint>
 #include "bamboo_tracker.hpp"
 #include "configuration.hpp"
+#include "instrument/sample_repeat.hpp"
 #include "gui/color_palette.hpp"
 
 namespace Ui {
@@ -56,8 +57,8 @@ public:
 
 	int getSampleNumber() const;
 
-	void setInstrumentSampleParameters(int sampNum, bool repeatable, int rKeyNum, int rDeltaN,
-									   size_t start, size_t stop, std::vector<uint8_t> sample);
+	void setInstrumentSampleParameters(int sampNum, bool repeatable, const SampleRepeatRange& repeatRange,
+									   int rKeyNum, int rDeltaN, size_t start, size_t stop, std::vector<uint8_t> sample);
 
 signals:
 	void modified();
@@ -112,6 +113,8 @@ private:
 private slots:
 	void on_sampleNumSpinBox_valueChanged(int arg1);
 	void on_repeatCheckBox_toggled(bool checked);
+	void on_repeatBeginSpinBox_valueChanged(int);
+	void on_repeatEndSpinBox_valueChanged(int);
 	void on_rootRateSpinBox_valueChanged(int arg1);
 	void on_action_Resize_triggered();
 	void on_actionRe_verse_triggered();

--- a/BambooTracker/gui/instrument_editor/adpcm_sample_editor.ui
+++ b/BambooTracker/gui/instrument_editor/adpcm_sample_editor.ui
@@ -136,6 +136,32 @@
       </widget>
      </item>
      <item>
+      <widget class="AdpcmStartAddressSpinBox" name="repeatBeginSpinBox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>70</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="AdpcmStopAddressSpinBox" name="repeatEndSpinBox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>70</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer_4">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -315,10 +341,24 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AdpcmStartAddressSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>gui/instrument_editor/adpcm_address_spin_box.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>AdpcmStopAddressSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>gui/instrument_editor/adpcm_address_spin_box.hpp</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>sampleNumSpinBox</tabstop>
   <tabstop>usersLineEdit</tabstop>
   <tabstop>repeatCheckBox</tabstop>
+  <tabstop>repeatBeginSpinBox</tabstop>
+  <tabstop>repeatEndSpinBox</tabstop>
   <tabstop>rootKeyComboBox</tabstop>
   <tabstop>rootKeySpinBox</tabstop>
   <tabstop>rootRateSpinBox</tabstop>

--- a/BambooTracker/instrument/instrument.cpp
+++ b/BambooTracker/instrument/instrument.cpp
@@ -536,6 +536,11 @@ bool InstrumentADPCM::isSampleRepeatable() const
 	return owner_->isSampleADPCMRepeatable(sampNum_);
 }
 
+SampleRepeatFlag InstrumentADPCM::getSampleRepeatFlag() const
+{
+	return owner_->getSampleADPCMRepeatFlag(sampNum_);
+}
+
 SampleRepeatRange InstrumentADPCM::getSampleRepeatRange() const
 {
 	return owner_->getSampleADPCMRepeatRange(sampNum_);
@@ -697,6 +702,11 @@ int InstrumentDrumkit::getSampleRootDeltaN(int key) const
 bool InstrumentDrumkit::isSampleRepeatable(int key) const
 {
 	return owner_->isSampleADPCMRepeatable(kit_.at(key).sampNum);
+}
+
+SampleRepeatFlag InstrumentDrumkit::getSampleRepeatFlag(int key) const
+{
+	return owner_->getSampleADPCMRepeatFlag(kit_.at(key).sampNum);
 }
 
 SampleRepeatRange InstrumentDrumkit::getSampleRepeatRange(int key) const

--- a/BambooTracker/instrument/instrument.cpp
+++ b/BambooTracker/instrument/instrument.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Rerrah
+ * Copyright (C) 2018-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -536,6 +536,11 @@ bool InstrumentADPCM::isSampleRepeatable() const
 	return owner_->isSampleADPCMRepeatable(sampNum_);
 }
 
+SampleRepeatRange InstrumentADPCM::getSampleRepeatRange() const
+{
+	return owner_->getSampleADPCMRepeatRange(sampNum_);
+}
+
 std::vector<uint8_t> InstrumentADPCM::getRawSample() const
 {
 	return owner_->getSampleADPCMRawSample(sampNum_);
@@ -692,6 +697,11 @@ int InstrumentDrumkit::getSampleRootDeltaN(int key) const
 bool InstrumentDrumkit::isSampleRepeatable(int key) const
 {
 	return owner_->isSampleADPCMRepeatable(kit_.at(key).sampNum);
+}
+
+SampleRepeatRange InstrumentDrumkit::getSampleRepeatRange(int key) const
+{
+	return owner_->getSampleADPCMRepeatRange(kit_.at(key).sampNum);
 }
 
 std::vector<uint8_t> InstrumentDrumkit::getRawSample(int key) const

--- a/BambooTracker/instrument/instrument.hpp
+++ b/BambooTracker/instrument/instrument.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Rerrah
+ * Copyright (C) 2018-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -32,6 +32,7 @@
 #include "envelope_fm.hpp"
 #include "lfo_fm.hpp"
 #include "sequence_property.hpp"
+#include "sample_repeat.hpp"
 #include "instrument_property_defs.hpp"
 #include "enum_hash.hpp"
 #include "bamboo_tracker_defs.hpp"
@@ -219,6 +220,7 @@ public:
 	int getSampleRootKeyNumber() const;
 	int getSampleRootDeltaN() const;
 	bool isSampleRepeatable() const;
+	SampleRepeatRange getSampleRepeatRange() const;
 	std::vector<uint8_t> getRawSample() const;
 	size_t getSampleStartAddress() const;
 	size_t getSampleStopAddress() const;
@@ -289,6 +291,7 @@ public:
 	int getSampleRootKeyNumber(int key) const;
 	int getSampleRootDeltaN(int key) const;
 	bool isSampleRepeatable(int key) const;
+	SampleRepeatRange getSampleRepeatRange(int key) const;
 	std::vector<uint8_t> getRawSample(int key) const;
 	size_t getSampleStartAddress(int key) const;
 	size_t getSampleStopAddress(int key) const;

--- a/BambooTracker/instrument/instrument.hpp
+++ b/BambooTracker/instrument/instrument.hpp
@@ -220,6 +220,7 @@ public:
 	int getSampleRootKeyNumber() const;
 	int getSampleRootDeltaN() const;
 	bool isSampleRepeatable() const;
+	SampleRepeatFlag getSampleRepeatFlag() const;
 	SampleRepeatRange getSampleRepeatRange() const;
 	std::vector<uint8_t> getRawSample() const;
 	size_t getSampleStartAddress() const;
@@ -291,6 +292,7 @@ public:
 	int getSampleRootKeyNumber(int key) const;
 	int getSampleRootDeltaN(int key) const;
 	bool isSampleRepeatable(int key) const;
+	SampleRepeatFlag getSampleRepeatFlag(int key) const;
 	SampleRepeatRange getSampleRepeatRange(int key) const;
 	std::vector<uint8_t> getRawSample(int key) const;
 	size_t getSampleStartAddress(int key) const;

--- a/BambooTracker/instrument/instruments_manager.cpp
+++ b/BambooTracker/instrument/instruments_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Rerrah
+ * Copyright (C) 2018-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -2024,6 +2024,16 @@ void InstrumentsManager::setSampleADPCMRepeatEnabled(int sampNum, bool enabled)
 bool InstrumentsManager::isSampleADPCMRepeatable(int sampNum) const
 {
 	return sampADPCM_.at(static_cast<size_t>(sampNum))->isRepeatable();
+}
+
+bool InstrumentsManager::setSampleADPCMRepeatrange(int sampNum, const SampleRepeatRange& range)
+{
+	return sampADPCM_.at(static_cast<size_t>(sampNum))->setRepeatRange(range);
+}
+
+SampleRepeatRange InstrumentsManager::getSampleADPCMRepeatRange(int sampNum) const
+{
+	return sampADPCM_.at(static_cast<size_t>(sampNum))->getRepeatRange();
 }
 
 void InstrumentsManager::storeSampleADPCMRawSample(int sampNum, const std::vector<uint8_t>& sample)

--- a/BambooTracker/instrument/instruments_manager.cpp
+++ b/BambooTracker/instrument/instruments_manager.cpp
@@ -2031,6 +2031,11 @@ bool InstrumentsManager::setSampleADPCMRepeatrange(int sampNum, const SampleRepe
 	return sampADPCM_.at(static_cast<size_t>(sampNum))->setRepeatRange(range);
 }
 
+SampleRepeatFlag InstrumentsManager::getSampleADPCMRepeatFlag(int sampNum) const
+{
+	return sampADPCM_.at(static_cast<size_t>(sampNum))->getRepeatFlag();
+}
+
 SampleRepeatRange InstrumentsManager::getSampleADPCMRepeatRange(int sampNum) const
 {
 	return sampADPCM_.at(static_cast<size_t>(sampNum))->getRepeatRange();

--- a/BambooTracker/instrument/instruments_manager.hpp
+++ b/BambooTracker/instrument/instruments_manager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Rerrah
+ * Copyright (C) 2018-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -321,6 +321,8 @@ public:
 	int getSampleADPCMRootDeltaN(int sampNum) const;
 	void setSampleADPCMRepeatEnabled(int sampNum, bool enabled);
 	bool isSampleADPCMRepeatable(int sampNum) const;
+	bool setSampleADPCMRepeatrange(int sampNum, const SampleRepeatRange& range);
+	SampleRepeatRange getSampleADPCMRepeatRange(int sampNum) const;
 	void storeSampleADPCMRawSample(int sampNum, const std::vector<uint8_t>& sample);
 	void storeSampleADPCMRawSample(int sampNum, std::vector<uint8_t>&& sample);
 	void clearSampleADPCMRawSample(int sampNum);

--- a/BambooTracker/instrument/instruments_manager.hpp
+++ b/BambooTracker/instrument/instruments_manager.hpp
@@ -322,6 +322,7 @@ public:
 	void setSampleADPCMRepeatEnabled(int sampNum, bool enabled);
 	bool isSampleADPCMRepeatable(int sampNum) const;
 	bool setSampleADPCMRepeatrange(int sampNum, const SampleRepeatRange& range);
+	SampleRepeatFlag getSampleADPCMRepeatFlag(int sampNum) const;
 	SampleRepeatRange getSampleADPCMRepeatRange(int sampNum) const;
 	void storeSampleADPCMRawSample(int sampNum, const std::vector<uint8_t>& sample);
 	void storeSampleADPCMRawSample(int sampNum, std::vector<uint8_t>&& sample);

--- a/BambooTracker/instrument/sample_adpcm.hpp
+++ b/BambooTracker/instrument/sample_adpcm.hpp
@@ -46,9 +46,21 @@ public:
 	int getRootKeyNumber() const noexcept {return rootKeyNum_; }
 	void setRootDeltaN(int dn) noexcept { rootDeltaN_ = dn; }
 	int getRootDeltaN() const noexcept { return rootDeltaN_; }
+
 	void setRepeatEnabled(bool enabled) noexcept { isRepeated_ = enabled; }
 	bool isRepeatable() const noexcept { return isRepeated_; }
+	SampleRepeatFlag getRepeatFlag() const noexcept {
+		if (!isRepeated_) return SampleRepeatFlag::Disabled;
 
+		int flags = SampleRepeatFlag::ShouldRepeat;
+		if (repeatRange_.first() != 0) {
+			flags |= SampleRepeatFlag::ShouldRewriteStart;
+		}
+		if (repeatRange_.last() != sample_.size() - 1) {
+			flags |= SampleRepeatFlag::ShouldRewriteStop;
+		}
+		return static_cast<SampleRepeatFlag>(flags);
+	}
 	bool setRepeatRange(const SampleRepeatRange& range) noexcept;
 	SampleRepeatRange getRepeatRange() const noexcept { return repeatRange_; }
 

--- a/BambooTracker/instrument/sample_adpcm.hpp
+++ b/BambooTracker/instrument/sample_adpcm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Rerrah
+ * Copyright (C) 2020-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -30,6 +30,7 @@
 #include <memory>
 #include <cmath>
 #include "abstract_instrument_property.hpp"
+#include "sample_repeat.hpp"
 
 class SampleADPCM final : public AbstractInstrumentProperty
 {
@@ -41,27 +42,31 @@ public:
 
 	std::unique_ptr<SampleADPCM> clone();
 
-	inline void setRootKeyNumber(int n) noexcept { rootKeyNum_ = n; }
-	inline int getRootKeyNumber() const noexcept {return rootKeyNum_; }
-	inline void setRootDeltaN(int dn) noexcept { rootDeltaN_ = dn; }
-	inline int getRootDeltaN() const noexcept { return rootDeltaN_; }
-	inline void setRepeatEnabled(bool enabled) noexcept { isRepeated_ = enabled; }
-	inline bool isRepeatable() const noexcept { return isRepeated_; }
-	inline void storeSample(const std::vector<uint8_t>& sample) { sample_ = sample; }
-	inline void storeSample(std::vector<uint8_t>&& sample) { sample_ = std::move(sample); }
-	inline std::vector<uint8_t> getSamples() const { return sample_; }
+	void setRootKeyNumber(int n) noexcept { rootKeyNum_ = n; }
+	int getRootKeyNumber() const noexcept {return rootKeyNum_; }
+	void setRootDeltaN(int dn) noexcept { rootDeltaN_ = dn; }
+	int getRootDeltaN() const noexcept { return rootDeltaN_; }
+	void setRepeatEnabled(bool enabled) noexcept { isRepeated_ = enabled; }
+	bool isRepeatable() const noexcept { return isRepeated_; }
+
+	bool setRepeatRange(const SampleRepeatRange& range) noexcept;
+	SampleRepeatRange getRepeatRange() const noexcept { return repeatRange_; }
+
+	bool storeSample(const std::vector<uint8_t>& sample);
+	bool storeSample(std::vector<uint8_t>&& sample);
+	std::vector<uint8_t> getSamples() const { return sample_; }
 	void clearSample();
-	inline void setStartAddress(size_t addr) noexcept { startAddress_ = addr; }
-	inline size_t getStartAddress() const noexcept { return startAddress_; }
-	inline void setStopAddress(size_t addr) noexcept { stopAddress_ = addr; }
-	inline size_t getStopAddress() const noexcept { return stopAddress_; }
+	void setStartAddress(size_t addr) noexcept { startAddress_ = addr; }
+	size_t getStartAddress() const noexcept { return startAddress_; }
+	void setStopAddress(size_t addr) noexcept { stopAddress_ = addr; }
+	size_t getStopAddress() const noexcept { return stopAddress_; }
 
 	bool isEdited() const override;
 	void clearParameters() override;
 
 	static constexpr int DEF_ROOT_KEY = 60;	// C5
 
-	inline static int calculateADPCMDeltaN(unsigned int rate)
+	static int calculateADPCMDeltaN(unsigned int rate)
 	{
 		return static_cast<int>(std::round((rate << 16) / 55500.));
 	}
@@ -69,6 +74,8 @@ public:
 private:
 	int rootKeyNum_, rootDeltaN_;
 	bool isRepeated_;
+	/// Range (first byte, last byte)
+	SampleRepeatRange repeatRange_;
 	std::vector<uint8_t> sample_;
 	size_t startAddress_, stopAddress_;
 };

--- a/BambooTracker/instrument/sample_repeat.hpp
+++ b/BambooTracker/instrument/sample_repeat.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Rerrah
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <stdexcept>
+
+enum class SampleRepeat { Disabled, Partial, Simple };
+
+/// Immutable safe range class
+/// handles position as ADPCM memory address by 32 bytes
+class SampleRepeatRange
+{
+public:
+	SampleRepeatRange(size_t first, size_t last)
+	{
+		if (last < first) {
+			throw std::invalid_argument("Invalid range");
+		}
+
+		first_ = first;
+		last_ = last;
+	}
+
+	size_t first() const noexcept { return first_; }
+	size_t last() const noexcept { return last_; }
+	SampleRepeatRange clampLast(size_t last) const noexcept
+	{
+		return SampleRepeatRange(std::min(first_, last), std::min(last_, last));
+	}
+
+private:
+	size_t first_, last_;
+};

--- a/BambooTracker/instrument/sample_repeat.hpp
+++ b/BambooTracker/instrument/sample_repeat.hpp
@@ -28,7 +28,27 @@
 #include <algorithm>
 #include <stdexcept>
 
-enum class SampleRepeat { Disabled, Partial, Simple };
+/// Repeat type
+enum SampleRepeatFlag : int
+{
+	ShouldRewriteStart	= 0b001,
+	ShouldRewriteStop	= 0b010,
+	ShouldRepeat		= 0b100,
+
+	/*
+	 * |---| repeat range
+	 * Disabled:		|        |
+	 * LeftPartial:		|-----|  |
+	 * RightPartial:	|  |-----|
+	 * MiddlePartial:	| |----| |
+	 * Simple:			|--------|
+	 */
+	Disabled		= 0,
+	LeftPartial		= ShouldRepeat | ShouldRewriteStop,
+	RightPartial	= ShouldRepeat | ShouldRewriteStart,
+	MiddlePartial	= ShouldRepeat | ShouldRewriteStart | ShouldRewriteStop,
+	Simple			= ShouldRepeat,
+};
 
 /// Immutable safe range class
 /// handles position as ADPCM memory address by 32 bytes

--- a/BambooTracker/io/p86_io.cpp
+++ b/BambooTracker/io/p86_io.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Rerrah
+ * Copyright (C) 2021-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -100,6 +100,8 @@ AbstractInstrument* P86IO::loadInstrument(const std::vector<uint8_t>& sample,
 	instManLocked->storeSampleADPCMRawSample(sampIdx, sample);
 	instManLocked->setSampleADPCMRootKeyNumber(sampIdx, 67);	// o5g
 	instManLocked->setSampleADPCMRootDeltaN(sampIdx, 0x4a0d);	// 16540Hz
+	instManLocked->setSampleADPCMRepeatEnabled(sampIdx, false);
+	instManLocked->setSampleADPCMRepeatrange(sampIdx, SampleRepeatRange(0, (sample.size() - 1) >> 5));
 
 	return adpcm;
 }

--- a/BambooTracker/io/pmb_io.cpp
+++ b/BambooTracker/io/pmb_io.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Rerrah
+ * Copyright (C) 2022-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -105,6 +105,8 @@ AbstractInstrument* PmbIO::loadInstrument(const std::vector<uint8_t>& sample,
 	instManLocked->storeSampleADPCMRawSample(sampIdx, sample);
 	instManLocked->setSampleADPCMRootKeyNumber(sampIdx, 67);	// o5g
 	instManLocked->setSampleADPCMRootDeltaN(sampIdx, 0x49cd); // 16000Hz
+	instManLocked->setSampleADPCMRepeatEnabled(sampIdx, false);
+	instManLocked->setSampleADPCMRepeatrange(sampIdx, SampleRepeatRange(0, (sample.size() - 1) >> 5));
 
 	return adpcm;
 }

--- a/BambooTracker/io/ppc_io.cpp
+++ b/BambooTracker/io/ppc_io.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Rerrah
+ * Copyright (C) 2020-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -82,6 +82,8 @@ AbstractInstrument* PpcIO::loadInstrument(const std::vector<uint8_t>& sample,
 	instManLocked->storeSampleADPCMRawSample(sampIdx, sample);
 	instManLocked->setSampleADPCMRootKeyNumber(sampIdx, 67);	// o5g
 	instManLocked->setSampleADPCMRootDeltaN(sampIdx, 0x49cd);	// 16000Hz
+	instManLocked->setSampleADPCMRepeatEnabled(sampIdx, false);
+	instManLocked->setSampleADPCMRepeatrange(sampIdx, SampleRepeatRange(0, (sample.size() - 1) >> 5));
 
 	return adpcm;
 }

--- a/BambooTracker/io/pps_io.cpp
+++ b/BambooTracker/io/pps_io.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Rerrah
+ * Copyright (C) 2021-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -80,6 +80,8 @@ AbstractInstrument* PpsIO::loadInstrument(const std::vector<uint8_t>& sample,
 	instManLocked->storeSampleADPCMRawSample(sampIdx, sample);
 	instManLocked->setSampleADPCMRootKeyNumber(sampIdx, 67);	// o5g
 	instManLocked->setSampleADPCMRootDeltaN(sampIdx, 0x49cd);	// 16000Hz
+	instManLocked->setSampleADPCMRepeatEnabled(sampIdx, false);
+	instManLocked->setSampleADPCMRepeatrange(sampIdx, SampleRepeatRange(0, (sample.size() - 1) >> 5));
 
 	return adpcm;
 }

--- a/BambooTracker/io/pvi_io.cpp
+++ b/BambooTracker/io/pvi_io.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Rerrah
+ * Copyright (C) 2020-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -79,6 +79,8 @@ AbstractInstrument* PviIO::loadInstrument(const std::vector<uint8_t>& sample, ui
 	instManLocked->storeSampleADPCMRawSample(sampIdx, sample);
 	instManLocked->setSampleADPCMRootKeyNumber(sampIdx, 60);	// o5c
 	instManLocked->setSampleADPCMRootDeltaN(sampIdx, deltaN);
+	instManLocked->setSampleADPCMRepeatEnabled(sampIdx, false);
+	instManLocked->setSampleADPCMRepeatrange(sampIdx, SampleRepeatRange(0, (sample.size() - 1) >> 5));
 
 	return adpcm;
 }

--- a/BambooTracker/io/pzi_io.cpp
+++ b/BambooTracker/io/pzi_io.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Rerrah
+ * Copyright (C) 2021-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -102,6 +102,7 @@ AbstractInstrument* PziIO::loadInstrument(const std::vector<uint8_t>& sample,
 	instManLocked->setSampleADPCMRootKeyNumber(sampIdx, 67);	// o5g
 	instManLocked->setSampleADPCMRootDeltaN(sampIdx, deltaN);
 	instManLocked->setSampleADPCMRepeatEnabled(sampIdx, isRepeated);
+	instManLocked->setSampleADPCMRepeatrange(sampIdx, SampleRepeatRange(0, (sample.size() - 1) >> 5));
 
 	return adpcm;
 }

--- a/BambooTracker/opna_controller.hpp
+++ b/BambooTracker/opna_controller.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Rerrah
+ * Copyright (C) 2018-2023 Rerrah
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -32,6 +32,7 @@
 #include "song.hpp"
 #include "instrument.hpp"
 #include "effect_iterator.hpp"
+#include "sample_repeat.hpp"
 #include "note.hpp"
 #include "echo_buffer.hpp"
 #include "chip/opna.hpp"
@@ -474,6 +475,7 @@ private:
 	int nsSumADPCM_;
 	int transposeADPCM_;
 	bool hasStartRequestedKit_;
+	std::vector<size_t> repeatAddrADPCM_;
 
 	void initADPCM();
 
@@ -501,7 +503,7 @@ private:
 
 	void setRealVolumeADPCM();
 
-	void triggerSamplePlayADPCM(size_t startAddress, size_t stopAddress, bool repeatable);
+	void triggerSamplePlayADPCM(size_t startAddress, size_t stopAddress, bool shouldRepeat);
 };
 
 //-----------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#433] - Add key cut note (thanks [@wildmatsu])
 - [#471] - Support FM Towns .pmb file import (thanks [@OPNA2608])
 - [#472] - Add SSG mixing level configuration for VGM export ([#436]; thanks [@ValleyBell], [@nyanpasu64])
+- Add partial repeat settings for ADPCM samples ([#465]; thanks [@pedipanol])
 
 ### Changed
 
@@ -47,6 +48,7 @@
 [#472]: https://github.com/BambooTracker/BambooTracker/pull/472
 [#436]: https://github.com/BambooTracker/BambooTracker/issues/436
 [#473]: https://github.com/BambooTracker/BambooTracker/pull/473
+[#465]: https://github.com/BambooTracker/BambooTracker/issues/465
 
 ## v0.5.3 (2022-09-18)
 

--- a/data/specs/bank_specs_v1.3.1.md
+++ b/data/specs/bank_specs_v1.3.1.md
@@ -1,8 +1,299 @@
 # BambooTracker Bank File (.btb) Format Specification
 
-v1.3.1 - 2022-11-06
+v1.3.1 - 2023-01-21
 
-This is a version revision to switch the loading process for files from previous versions due to changes in instrument sequence behaviour. The file specification is exactly the same as [v1.3.0](./archives/bank_specs_v1.3.0.md).
+- All data are little endian.
+- Unless otherwise noted, character encoding of string is ASCII.
+
+---
+
+## Header
+
+| Type              | Field           | Description                                                               |
+| ----------------- | --------------- | ------------------------------------------------------------------------- |
+| string (16 bytes) | File identifier | Format string, must be `BambooTrackerBnk`.                                |
+| uint32            | EOF offset      | Relative offset to end of file. i.e. File length - 18.                    |
+| uint32            | File version    | Version number in BCD-Code. e.g. Version 1.3.0 is stored as `0x00010300`. |
+
+## Instrument Section
+
+| Type             | Field                     | Description                                   |
+| ---------------- | ------------------------- | --------------------------------------------- |
+| string (8 bytes) | Section identifier        | Must be `INSTRMNT`.                           |
+| uint32           | Instrument section offset | Relative offset to end of instrument section. |
+| uint8            | Instrument count          | Number of instruments.                        |
+
+After instrument count, details of each instrument are described.
+
+| Type             | Field                  | Description                                                                                                   |
+| ---------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------- |
+| uint8            | Instrument index       | Index of the instrument.                                                                                      |
+| uint32           | instrument offset      | Relative offset to end of the instrument details.                                                             |
+| uint32           | Instrument name length | Length of instrument name.                                                                                    |
+| string (N bytes) | Instrument name        | String of instrument name. Character encoding is UTF-8. If instrument name is not set, this field is omitted. |
+| uint8            | Instrument type        | Type of the instrument. `0x00`: FM, `0x01`: SSG, `0x02`: ADPCM, `0x03`: Drumkit.                              |
+
+The following data change depending on sound source of the instrument.
+
+### FM
+
+| Type  | Field              | Description                                                                                      |
+| ----- | ------------------ | ------------------------------------------------------------------------------------------------ |
+| uint8 | Envelope number    | Envelope number.                                                                                 |
+| uint8 | LFO number         | Bit 0-6 is LFO number, and bit 7 is flag. If bit 7 is clear, it uses LFO.                        |
+| uint8 | AL sequence number | Bit 0-6 is algorithm sequence number, and bit 7 is flag. If bit 7 is clear, it uses AL sequence. |
+| uint8 | FB sequence number | Bit 0-6 is feedback sequence number, and bit 7 is flag. If bit 7 is clear, it uses FB sequence.  |
+
+After FB sequence number, it repeats 9 operator's parameters for each operator (1-4).
+
+| Type  | Field              | Description                                                                                                          |
+| ----- | ------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| uint8 | AR sequence number | Bit 0-6 is attack rate sequence number of the operator, and bit 7 is flag. If bit 7 is clear, it uses AR sequence.   |
+| uint8 | DR sequence number | Bit 0-6 is decay rate sequence number of the operator, and bit 7 is flag. If bit 7 is clear, it uses DR sequence.    |
+| uint8 | SR sequence number | Bit 0-6 is sustain rate sequence number of the operator, and bit 7 is flag. If bit 7 is clear, it uses SR sequence.  |
+| uint8 | RR sequence number | Bit 0-6 is release rate sequence number of the operator, and bit 7 is flag. If bit 7 is clear, it uses RR sequence.  |
+| uint8 | SL sequence number | Bit 0-6 is sustain level sequence number of the operator, and bit 7 is flag. If bit 7 is clear, it uses SL sequence. |
+| uint8 | TL sequence number | Bit 0-6 is total level sequence number of the operator, and bit 7 is flag. If bit 7 is clear, it uses TL sequence.   |
+| uint8 | KS sequence number | Bit 0-6 is key scale sequence number of the operator, and bit 7 is flag. If bit 7 is clear, it uses KS sequence.     |
+| uint8 | ML sequence number | Bit 0-6 is multiple sequence number of the operator, and bit 7 is flag. If bit 7 is clear, it uses ML sequence.      |
+| uint8 | DT sequence number | Bit 0-6 is detune sequence number of the operator, and bit 7 is flag. If bit 7 is clear, it uses DT sequence.        |
+
+| Type  | Field                               | Description                                                                                                                                                            |
+| ----- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| uint8 | Arpeggio sequence number            | Bit 0-6 is arpeggio sequence number, and bit 7 is flag. If bit 7 is clear, it uses arpeggio sequence for all operators.                                                |
+| uint8 | Pitch sequence number               | Bit 0-6 is pitch sequence number, and bit 7 is flag. If bit 7 is clear, it uses pitch sequence for all operators.                                                      |
+| uint8 | Envelope reset flag                 | Flag for envelope reset. Bit 0 is for all operators, bit 1 is for operator 1 and bit 3 is for operator 4. If bit is set, envelope reset is enabled for correspondings. |
+| uint8 | Operator 1 arpeggio sequence number | Bit 0-6 is arpeggio sequence number, and bit 7 is flag. If bit 7 is clear, it uses operator 1 arpeggio sequence in FM 3ch expansion mode.                              |
+| uint8 | Operator 2 arpeggio sequence number | Bit 0-6 is arpeggio sequence number, and bit 7 is flag. If bit 7 is clear, it uses operator 2 arpeggio sequence in FM 3ch expansion mode.                              |
+| uint8 | Operator 3 arpeggio sequence number | Bit 0-6 is arpeggio sequence number, and bit 7 is flag. If bit 7 is clear, it uses operator 3 arpeggio sequence in FM 3ch expansion mode.                              |
+| uint8 | Operator 4 arpeggio sequence number | Bit 0-6 is arpeggio sequence number, and bit 7 is flag. If bit 7 is clear, it uses operator 4 arpeggio sequence in FM 3ch expansion mode.                              |
+| uint8 | Operator 1 pitch sequence number    | Bit 0-6 is pitch sequence number, and bit 7 is flag. If bit 7 is clear, it uses operator 1 pitch sequence in FM 3ch expansion mode.                                    |
+| uint8 | Operator 2 pitch sequence number    | Bit 0-6 is pitch sequence number, and bit 7 is flag. If bit 7 is clear, it uses operator 2 pitch sequence in FM 3ch expansion mode.                                    |
+| uint8 | Operator 3 pitch sequence number    | Bit 0-6 is pitch sequence number, and bit 7 is flag. If bit 7 is clear, it uses operator 3 pitch sequence in FM 3ch expansion mode.                                    |
+| uint8 | Operator 4 pitch sequence number    | Bit 0-6 is pitch sequence number, and bit 7 is flag. If bit 7 is clear, it uses operator 4 pitch sequence in FM 3ch expansion mode.                                    |
+| uint8 | Panning sequence number             | Bit 0-6 is panning sequence number, and bit 7 is flag. If bit 7 is clear, it uses panning sequence.                                                                    |
+
+### SSG
+
+| Type  | Field                      | Description                                                                                               |
+| ----- | -------------------------- | --------------------------------------------------------------------------------------------------------- |
+| uint8 | Waveform sequence number   | Bit 0-6 is waveform sequence number, and bit 7 is flag. If bit 7 is clear, it uses waveform sequence.     |
+| uint8 | Tone/Noise sequence number | Bit 0-6 is tone/noise sequence number, and bit 7 is flag. If bit 7 is clear, it uses tone/noise sequence. |
+| uint8 | Envelope sequence number   | Bit 0-6 is envelope sequence number, and bit 7 is flag. If bit 7 is clear, it uses envelope sequence.     |
+| uint8 | Arpeggio sequence number   | Bit 0-6 is arpeggio sequence number, and bit 7 is flag. If bit 7 is clear, it uses arpeggio sequence.     |
+| uint8 | Pitch sequence number      | Bit 0-6 is pitch sequence number, and bit 7 is flag. If bit 7 is clear, it uses pitch sequence.           |
+
+### ADPCM
+
+| Type  | Field                    | Description                                                                                           |
+| ----- | ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| uint8 | Sample                   | Sample number.                                                                                        |
+| uint8 | Envelope sequence number | Bit 0-6 is envelope sequence number, and bit 7 is flag. If bit 7 is clear, it uses envelope sequence. |
+| uint8 | Arpeggio sequence number | Bit 0-6 is arpeggio sequence number, and bit 7 is flag. If bit 7 is clear, it uses arpeggio sequence. |
+| uint8 | Pitch sequence number    | Bit 0-6 is pitch sequence number, and bit 7 is flag. If bit 7 is clear, it uses pitch sequence.       |
+| uint8 | Panning sequence number  | Bit 0-6 is panning sequence number, and bit 7 is flag. If bit 7 is clear, it uses panning sequence.   |
+
+### ADPCM Drumkit
+
+| Type  | Field     | Description                 |
+| ----- | --------- | --------------------------- |
+| uint8 | Key count | The count of assigned keys. |
+
+After key count, it repeats data of assigned key.
+
+| Type  | Field         | Description                       |
+| ----- | ------------- | --------------------------------- |
+| uint8 | Key number    | Assigned key number.              |
+| uint8 | Sample number | Sample number.                    |
+| int8  | Key pitch     | Assigned key pitch.               |
+| uint8 | Panning flags | Bit 0 is right and bit 1 is left. |
+
+## Instrument Property Section
+
+| Type            | Field                              | Description                                            |
+| --------------- | ---------------------------------- | ------------------------------------------------------ |
+| string (8bytes) | Seciton identifier                 | Must be `INSTPROP`.                                    |
+| uint32          | Instrument property section offset | Relative offset to end of instrument property section. |
+
+This section contains subsections of each instrument property.
+
+| Type  | Field                 | Description                                            |
+| ----- | --------------------- | ------------------------------------------------------ |
+| uint8 | Subsection identifier | Identify subsection type. See table below for details. |
+| uint8 | block count           | Number of property blocks.                             |
+
+Subsection identifier is defined as:
+
+| Value         | Subsection type                                                      |
+| ------------- | -------------------------------------------------------------------- |
+| `0x00`        | FM envelope                                                          |
+| `0x01`        | FM LFO                                                               |
+| `0x02`        | FM AL sequence                                                       |
+| `0x03`        | FM FB sequence                                                       |
+| `0x04`-`0x0C` | FM operator 1 sequences (in the order defined in instrument section) |
+| `0x0E`-`0x15` | FM operator 2 sequences (in the order defined in instrument section) |
+| `0x16`-`0x1E` | FM operator 3 sequences (in the order defined in instrument section) |
+| `0x1F`-`0x27` | FM operator 4 sequences (in the order defined in instrument section) |
+| `0x28`        | FM arpeggio sequence                                                 |
+| `0x29`        | FM pitch sequence                                                    |
+| `0x2A`        | FM panning sequence                                                  |
+| `0x30`        | SSG waveform sequence                                                |
+| `0x31`        | SSG tone/noise sequence                                              |
+| `0x32`        | SSG envelope sequence                                                |
+| `0x33`        | SSG arpeggio sequence                                                |
+| `0x34`        | SSG pitch sequence                                                   |
+| `0x40`        | ADPCM sample                                                         |
+| `0x41`        | ADPCM envelope sequence                                              |
+| `0x42`        | ADPCM arpeggio sequence                                              |
+| `0x43`        | ADPCM pitch sequence                                                 |
+| `0x44`        | ADPCM panning sequence                                               |
+
+ And repeats sequence data block.
+
+### FM Envelope
+
+| Type  | Field  | Description                                           |
+| ----- | ------ | ----------------------------------------------------- |
+| uint8 | Index  | Envelope index number.                                |
+| uint8 | Offset | Relative offset to end of the envelope block.         |
+| uint8 | AL/FB  | High nibble is algorithm, and low nibble is feedback. |
+
+After this, repeat parameters in the table below for each operator.
+
+| Type  | Field     | Description                                                                                       |
+| ----- | --------- | ------------------------------------------------------------------------------------------------- |
+| uint8 | Enable/AR | Flag which the operator is enabled when bit 5 is set, and attack rate is bit 0-4.                 |
+| uint8 | KS/DR     | Bit 0-4 is decay rate, and bit 5-6 is key scale.                                                  |
+| uint8 | DT/SR     | Bit 0-4 is sustain rate, and bit 5-7 is detune.                                                   |
+| uint8 | SL/RR     | Low nibble is release, and High nibble is sustain level.                                          |
+| uint8 | TL        | Total level.                                                                                      |
+| uint8 | SSGEGs/ML | Low nibble is multiple, high nibble is type of SSGEG. If SSGEG is disabled, high nibble is `0x8`. |
+
+### FM LFO
+
+| Type  | Field         | Description                                                                                                                                                      |
+| ----- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| uint8 | Index         | LFO index number.                                                                                                                                                |
+| uint8 | Offset        | Relative offset to end of the LFO block.                                                                                                                         |
+| uint8 | Frequency/PMS | High nibble is LFO moduletion frequency, and low nibble is phase modulation sensitivity.                                                                         |
+| uint8 | AMops/AMS     | high nibble is AM operator flags and low nibble is amplitude modulation sensitivity. Bit 4 is operator 1 and bit 7 is operator 4. If flag is set, AM is enabled. |
+| uint8 | Start count   | Tick wait count before beginning LFO.                                                                                                                            |
+
+### ADPCM sample
+
+| Type      | Field                   | Description                                                 |
+| --------- | ----------------------- | ----------------------------------------------------------- |
+| uint8     | Index                   | Sample index number.                                        |
+| uint32    | Offset                  | Relative offset to end of the sample block.                 |
+| uint8     | Root key                | Root key number.                                            |
+| uint16    | Root delta-N            | Delta-N (sample rate) in root key.                          |
+| uint8     | Repeat flag             | If bit 0 is set, this ADPCM sample is played repeatedly.    |
+| uint32    | Sample length           | Length of ADPCM sample.                                     |
+| uint8 x N | Sample                  | Raw ADPCM sample is stored.                                 |
+| uint16    | Repeat beginning offset | Offset of repeat beginning point from sample start address. |
+| uint16    | Repeat ending offset    | Offset of repeat ending point from sample start address.    |
+
+### Sequence
+
+Sequence-type data block (e.g. FM arpeggio, SSG envelope) is defined as:
+
+| Type   | Field           | Description                                   |
+| ------ | --------------- | --------------------------------------------- |
+| uint8  | Index           | Index number.                                 |
+| uint16 | Offset          | Relative offset to end of the sequence block. |
+| uint16 | Sequence length | Length of sequence.                           |
+
+And repeat sequence data units.
+
+| Type   | Field        | Description                                                                                                                            |
+| ------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| uint16 | Unit data    | Value of unit. This also indicates row number of sequence editor. For details, see the subsection *Sequence Unit*.                     |
+| int32  | Unit subdata | Unit subdata. Only used by SSG waveform and envelope, and omitted in other sequences. For details, see the subsection *Sequence Unit*. |
+
+After sequences, loops are stored.
+
+| Type   | Field       | Description      |
+| ------ | ----------- | ---------------- |
+| uint16 | Loop counts | Number of loops. |
+
+Loop unit is defined as the table below. If it is stored `0x00` in loop counts i.g. there is no loop, the unit is omitted.
+
+| Type   | Field        | Description                                                                             |
+| ------ | ------------ | --------------------------------------------------------------------------------------- |
+| uint16 | Begin point  | Count from head of sequence where loop starts.                                          |
+| uint16 | End point    | Count from head of sequence where loop stops.                                           |
+| uint8  | Repeat count | Count of loop repeating. Note: If `0x01` is stored, it is interpreted as infinity loop. |
+
+There is release details in the end of subsequence block.
+
+| Type   | Field         | Description                                                                                                                                                                 |
+| ------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| uint8  | Release type  | `0x00`: no release, `0x01`: fixed, `0x02`: absolute, `0x03`: releative. SSG envelope can be selected from all of these, and other properties can use only `0x00` or `0x01`. |
+| uint16 | Release point | Count from head of sequence where loop starts. If release type is `0x00`, this field is omitted.                                                                            |
+
+| Type  | Field         | Description                                    |
+| ----- | ------------- | ---------------------------------------------- |
+| uint8 | Sequence type | Type of sequence. See table below for details. |
+
+Sequence type is defined as:
+
+| Value  | Type      |
+| ------ | --------- |
+| `0x00` | Absolute. |
+| `0x01` | Fixed.    |
+| `0x02` | Relative. |
+
+FM/SSG arpeggio can be selected from all of these, FM/SSG pitch can be absolute or relative, and other properties must be set to `0x00`.
+
+#### Sequence Unit
+
+In FM Operator sequence, unit data is the value of operator parameter.
+
+In FM and SSG arpeggio, unit data has 2 interpretations depending on its sequence type:
+
+- Absolute, Relative: Tone distance from the criterion 0.
+- Fixed: Tone distance from C4.
+
+In FM and SSG pitch, unit data is the tone distance from the criterion 0.
+
+In SSG waveform, unit data represents the waveform:
+
+| Unit data | Waveform                        |
+| --------- | ------------------------------- |
+| `0x00`    | Square                          |
+| `0x01`    | Triangle                        |
+| `0x02`    | Sawtooth                        |
+| `0x03`    | Inversed sawtooth               |
+| `0x04`    | Square-masked triangle          |
+| `0x05`    | Square-masked sawtooth          |
+| `0x06`    | Square-masked inversed sawtooth |
+
+When waveform is square-masked, unit subdata is set one of the 2 types of data:
+
+- If bit 16 is 0, it is raw data. Bit 0-11 is square mask period.
+- If bit 16 is 1, it is tone/mask ratio. Bit 0-7 is mask part and bit 8-15 is tone part.
+
+The other waveform set unit subdata to `-1`.
+
+In SSG tone/noise, unit data defined as:
+
+| Unit data     | Type                                               |
+| ------------- | -------------------------------------------------- |
+| `0x00`        | Tone.                                              |
+| `0x01`-`0x20` | Noise. The period is set as `value` - 1.           |
+| `0x21`-`0x40` | Tone & Noise. Noise period is set as `value` - 33. |
+
+In SSG envelope, unit data defined as:
+
+| Unit data     | Type                                                                                     |
+| ------------- | ---------------------------------------------------------------------------------------- |
+| `0x00`-`0x0F` | Software envelope. The value represents SSG channel volume. Unit subdata is set as `-1`. |
+| `0x10`-`0x17` | Hardware envelope. The envelope shape number is specified as `value` - 16.               |
+
+When unit data is set to use hardware envelope, unit subdata is set one of the 2 types of data:
+
+- If bit 16 is 0, it is raw data. Bit 0-15 is hardware envelope period.
+- If bit 16 is 1, it is tone/hard ratio. Bit 0-7 is hard part and bit 8-15 is tone part.
 
 ---
 
@@ -10,7 +301,7 @@ This is a version revision to switch the loading process for files from previous
 
 | Version | Date       | Detail                                                                                          |
 | ------- | ---------- | ----------------------------------------------------------------------------------------------- |
-| 1.3.1   | 2022-11-06 | Revised to change the behaviour of instrument sequence.                                         |
+| 1.3.1   | 2023-01-21 | Add ADPCM sample repeat range settings.                                                         |
 | 1.3.0   | 2021-06-13 | Added FM/ADPCM panning sequence, drumkit panning, and removed unused subdata of ADPCM envelope. |
 | 1.2.0   | 2020-04-28 | Added ADPCM drumkit instrument.                                                                 |
 | 1.1.0   | 2020-02-25 | Added ADPCM instrument.                                                                         |

--- a/data/specs/inst_specs_v1.5.1.md
+++ b/data/specs/inst_specs_v1.5.1.md
@@ -1,8 +1,254 @@
 # BambooTracker Instrument File (.bti) Format Specification
 
-v1.5.1 - 2022-11-06
+v1.5.1 - 2023-01-21
 
-This is a version revision to switch the loading process for files from previous versions due to changes in instrument sequence behaviour. The file specification is exactly the same as [v1.5.0](./archives/inst_specs_v1.5.0.md).
+- All data are little endian.
+- Unless otherwise noted, character encoding of string is ASCII.
+
+---
+
+## Header
+
+| Type              | Field           | Description                                                               |
+| ----------------- | --------------- | ------------------------------------------------------------------------- |
+| string (16 bytes) | File identifier | Format string, must be `BambooTrackerIst`.                                |
+| uint32            | EOF offset      | Relative offset to end of file. i.e. File length - 18.                    |
+| uint32            | File version    | Version number in BCD-Code. e.g. Version 1.5.0 is stored as `0x00010500`. |
+
+## Instrument Section
+
+| Type             | Field                     | Description                                                                                                   |
+| ---------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| string (8 bytes) | Section identifier        | Must be `INSTRMNT`.                                                                                           |
+| uint32           | Instrument section offset | Relative offset to end of instrument section.                                                                 |
+| uint32           | Instrument name length    | Length of instrument name.                                                                                    |
+| string (N bytes) | Instrument name           | String of instrument name. Character encoding is UTF-8. If instrument name is not set, this field is omitted. |
+| uint8            | Instrument type           | Type of the instrument. `0x00`: FM, `0x01`: SSG, `0x02`: ADPCM, `0x03`: Drumkit.                              |
+
+The following data change depending on sound source of the instrument.
+
+### FM
+
+| Type  | Field                         | Description                                                                                                                                                            |
+| ----- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| uint8 | Envelope reset flag           | Flag for envelope reset. Bit 0 is for all operators, bit 1 is for operator 1 and bit 3 is for operator 4. If bit is set, envelope reset is enabled for correspondings. |
+| uint8 | All operators arpeggio number | If bit 7 is clear, arpeggio for all operators is enabled. bit 0-6 are the number: n-th FM arpeggio property. n have to be 0 if it is unused.                           |
+| uint8 | Operator 1 arpeggio number    | If bit 7 is clear, operator 1 arpeggio is enabled. bit 0-6 are the number: n-th FM arpeggio property. n have to be 0 if it is unused.                                  |
+| uint8 | Operator 2 arpeggio number    | If bit 7 is clear, operator 2 arpeggio is enabled. bit 0-6 are the number: n-th FM arpeggio property. n have to be 0 if it is unused.                                  |
+| uint8 | Operator 3 arpeggio number    | If bit 7 is clear, operator 3 arpeggio is enabled. bit 0-6 are the number: n-th FM arpeggio property. n have to be 0 if it is unused.                                  |
+| uint8 | Operator 4 arpeggio number    | If bit 7 is clear, operator 4 arpeggio is enabled. bit 0-6 are the number: n-th FM arpeggio property. n have to be 0 if it is unused.                                  |
+| uint8 | All operators pitch number    | If bit 7 is clear, pitch for all operators is enabled. bit 0-6 are the number: n-th FM pitch property. n have to be 0 if it is unused.                                 |
+| uint8 | Operator 1 pitch number       | If bit 7 is clear, operator 1 pitch is enabled. bit 0-6 are the number: n-th FM pitch property. n have to be 0 if it is unused.                                        |
+| uint8 | Operator 2 pitch number       | If bit 7 is clear, operator 2 pitch is enabled. bit 0-6 are the number: n-th FM pitch property. n have to be 0 if it is unused.                                        |
+| uint8 | Operator 3 pitch number       | If bit 7 is clear, operator 3 pitch is enabled. bit 0-6 are the number: n-th FM pitch property. n have to be 0 if it is unused.                                        |
+| uint8 | Operator 4 pitch number       | If bit 7 is clear, operator 4 pitch is enabled. bit 0-6 are the number: n-th FM pitch property. n have to be 0 if it is unused.                                        |
+
+### SSG
+
+SSG instrument has no specific data.
+
+### ADPCM
+
+ADPCM instrument has no specific data.
+
+### ADPCM Drumkit
+
+| Type  | Field     | Description                 |
+| ----- | --------- | --------------------------- |
+| uint8 | Key count | The count of assigned keys. |
+
+After key count, it repeats data of assigned key.
+
+| Type  | Field         | Description                       |
+| ----- | ------------- | --------------------------------- |
+| uint8 | Key number    | Assigned key number.              |
+| uint8 | Sample ID     | Sample identifier.                |
+| int8  | Key pitch     | Assigned key pitch.               |
+| uint8 | Panning flags | Bit 0 is right and bit 1 is left. |
+
+## Instrument Property Section
+
+| Type            | Field                              | Description                                            |
+| --------------- | ---------------------------------- | ------------------------------------------------------ |
+| string (8bytes) | Seciton identifier                 | Must be `INSTPROP`.                                    |
+| uint32          | Instrument property section offset | Relative offset to end of instrument property section. |
+
+This section contains subsections of each instrument property.
+
+| Type  | Field                 | Description                                            |
+| ----- | --------------------- | ------------------------------------------------------ |
+| uint8 | Subsection identifier | Identify subsection type. See table below for details. |
+
+Subsection identifier is defined as:
+
+| Value         | Subsection type                                                      |
+| ------------- | -------------------------------------------------------------------- |
+| `0x00`        | FM envelope                                                          |
+| `0x01`        | FM LFO                                                               |
+| `0x02`        | FM AL sequence                                                       |
+| `0x03`        | FM FB sequence                                                       |
+| `0x04`-`0x0C` | FM operator 1 sequences (in the order defined in instrument section) |
+| `0x0E`-`0x15` | FM operator 2 sequences (in the order defined in instrument section) |
+| `0x16`-`0x1E` | FM operator 3 sequences (in the order defined in instrument section) |
+| `0x1F`-`0x27` | FM operator 4 sequences (in the order defined in instrument section) |
+| `0x28`        | FM arpeggio sequence                                                 |
+| `0x29`        | FM pitch sequence                                                    |
+| `0x2A`        | FM panning sequence                                                  |
+| `0x30`        | SSG waveform sequence                                                |
+| `0x31`        | SSG tone/noise sequence                                              |
+| `0x32`        | SSG envelope sequence                                                |
+| `0x33`        | SSG arpeggio sequence                                                |
+| `0x34`        | SSG pitch sequence                                                   |
+| `0x40`        | ADPCM sample                                                         |
+| `0x41`        | ADPCM envelope sequence                                              |
+| `0x42`        | ADPCM arpeggio sequence                                              |
+| `0x43`        | ADPCM pitch sequence                                                 |
+| `0x44`        | ADPCM panning sequence                                               |
+
+And repeats sequence data block.  
+Note that multiple FM arpeggio and pitch sequences can be described for each operator.
+ADPCM samples are assigned IDs in the order in which they are stored.
+
+### FM envelope
+
+| Type  | Field  | Description                                           |
+| ----- | ------ | ----------------------------------------------------- |
+| uint8 | Offset | Relative offset to end of the envelope block.         |
+| uint8 | AL/FB  | High nibble is algorithm, and low nibble is feedback. |
+
+After this, repeat parameters in the table below for each operator.
+
+| Type  | Field     | Description                                                                                       |
+| ----- | --------- | ------------------------------------------------------------------------------------------------- |
+| uint8 | Enable/AR | Flag which the operator is enabled when bit 5 is set, and attack rate is bit 0-4.                 |
+| uint8 | KS/DR     | Bit 0-4 is decay rate, and bit 5-6 is key scale.                                                  |
+| uint8 | DT/SR     | Bit 0-4 is sustain rate, and bit 5-7 is detune.                                                   |
+| uint8 | SL/RR     | Low nibble is release, and High nibble is sustain level.                                          |
+| uint8 | TL        | Total level.                                                                                      |
+| uint8 | SSGEGs/ML | Low nibble is multiple, high nibble is type of SSGEG. If SSGEG is disabled, high nibble is `0x8`. |
+
+### FM LFO
+
+| Type  | Field         | Description                                                                                                                                                      |
+| ----- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| uint8 | Offset        | Relative offset to end of the LFO block.                                                                                                                         |
+| uint8 | Frequency/PMS | High nibble is LFO moduletion frequency, and low nibble is phase modulation sensitivity.                                                                         |
+| uint8 | AMops/AMS     | high nibble is AM operator flags and low nibble is amplitude modulation sensitivity. Bit 4 is operator 1 and bit 7 is operator 4. If flag is set, AM is enabled. |
+| uint8 | Start count   | Tick wait count before beginning LFO.                                                                                                                            |
+
+### ADPCM sample
+
+| Type      | Field                   | Description                                                 |
+| --------- | ----------------------- | ----------------------------------------------------------- |
+| uint32    | Offset                  | Relative offset to end of the sample block.                 |
+| uint8     | Root key                | Root key number.                                            |
+| uint16    | Root delta-N            | Delta-N (sample rate) in root key.                          |
+| uint8     | Repeat flag             | If bit 0 is set, this ADPCM sample is played repeatedly.    |
+| uint32    | Sample length           | Length of ADPCM sample.                                     |
+| uint8 x N | Sample                  | Raw ADPCM sample is stored.                                 |
+| uint16    | Repeat beginning offset | Offset of repeat beginning point from sample start address. |
+| uint16    | Repeat ending offset    | Offset of repeat ending point from sample start address.    |
+
+### Sequence
+
+Sequence-type data block (e.g. FM arpeggio, SSG envelope) is defined as:
+
+| Type   | Field           | Description                                   |
+| ------ | --------------- | --------------------------------------------- |
+| uint16 | Offset          | Relative offset to end of the sequence block. |
+| uint16 | Sequence length | Length of sequence.                           |
+
+And repeat sequence data units.
+
+| Type   | Field        | Description                                                                                                                            |
+| ------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| uint16 | Unit data    | Value of unit. This also indicates row number of sequence editor. For details, see the subsection *Sequence Unit*.                     |
+| int32  | Unit subdata | Unit subdata. Only used by SSG waveform and envelope, and omitted in other sequences. For details, see the subsection *Sequence Unit*. |
+
+After sequences, loops are stored.
+
+| Type   | Field       | Description      |
+| ------ | ----------- | ---------------- |
+| uint16 | Loop counts | Number of loops. |
+
+Loop unit is defined as the table below. If it is stored `0x00` in loop counts i.g. there is no loop, the unit is omitted.
+
+| Type   | Field        | Description                                                                             |
+| ------ | ------------ | --------------------------------------------------------------------------------------- |
+| uint16 | Begin point  | Count from head of sequence where loop starts.                                          |
+| uint16 | End point    | Count from head of sequence where loop stops.                                           |
+| uint8  | Repeat count | Count of loop repeating. Note: If `0x01` is stored, it is interpreted as infinity loop. |
+
+There is release details in the end of subsequence block.
+
+| Type   | Field         | Description                                                                                                                                                                 |
+| ------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| uint8  | Release type  | `0x00`: no release, `0x01`: fixed, `0x02`: absolute, `0x03`: releative. SSG envelope can be selected from all of these, and other properties can use only `0x00` or `0x01`. |
+| uint16 | Release point | Count from head of sequence where loop starts. If release type is `0x00`, this field is omitted.                                                                            |
+
+| Type  | Field         | Description                                    |
+| ----- | ------------- | ---------------------------------------------- |
+| uint8 | Sequence type | Type of sequence. See table below for details. |
+
+Sequence type is defined as:
+
+| Value  | Type      |
+| ------ | --------- |
+| `0x00` | Absolute. |
+| `0x01` | Fixed.    |
+| `0x02` | Relative. |
+
+FM/SSG arpeggio can be selected from all of these, FM/SSG pitch can be absolute or relative, and other properties must be set to `0x00`.
+
+#### Sequence Unit
+
+In FM Operator sequence, unit data is the value of operator parameter.
+
+In FM and SSG arpeggio, unit data has 2 interpretations depending on its sequence type:
+
+- Absolute, Relative: Tone distance from the criterion 0.
+- Fixed: Tone distance from C4.
+
+In FM and SSG pitch, unit data is the tone distance from the criterion 0.
+
+In SSG waveform, unit data represents the waveform:
+
+| Unit data | Waveform                        |
+| --------- | ------------------------------- |
+| `0x00`    | Square                          |
+| `0x01`    | Triangle                        |
+| `0x02`    | Sawtooth                        |
+| `0x03`    | Inversed sawtooth               |
+| `0x04`    | Square-masked triangle          |
+| `0x05`    | Square-masked sawtooth          |
+| `0x06`    | Square-masked inversed sawtooth |
+
+When waveform is square-masked, unit subdata is set one of the 2 types of data:
+
+- If bit 16 is 0, it is raw data. Bit 0-11 is square mask period.
+- If bit 16 is 1, it is tone/mask ratio. Bit 0-7 is mask part and bit 8-15 is tone part.
+
+The other waveform set unit subdata to `-1`.
+
+In SSG tone/noise, unit data defined as:
+
+| Unit data     | Type                                               |
+| ------------- | -------------------------------------------------- |
+| `0x00`        | Tone.                                              |
+| `0x01`-`0x20` | Noise. The period is set as `value` - 1.           |
+| `0x21`-`0x40` | Tone & Noise. Noise period is set as `value` - 33. |
+
+In SSG envelope, unit data defined as:
+
+| Unit data     | Type                                                                                     |
+| ------------- | ---------------------------------------------------------------------------------------- |
+| `0x00`-`0x0F` | Software envelope. The value represents SSG channel volume. Unit subdata is set as `-1`. |
+| `0x10`-`0x17` | Hardware envelope. The envelope shape number is specified as `value` - 16.               |
+
+When unit data is set to use hardware envelope, unit subdata is set one of the 2 types of data:
+
+- If bit 16 is 0, it is raw data. Bit 0-15 is hardware envelope period.
+- If bit 16 is 1, it is tone/hard ratio. Bit 0-7 is hard part and bit 8-15 is tone part.
 
 ---
 
@@ -10,7 +256,7 @@ This is a version revision to switch the loading process for files from previous
 
 | Version | Date       | Detail                                                                                          |
 | ------- | ---------- | ----------------------------------------------------------------------------------------------- |
-| 1.5.1   | 2022-11-06 | Revised to change the behaviour of instrument sequence.                                         |
+| 1.5.1   | 2023-01-21 | Add ADPCM sample repeat range settings.                                                         |
 | 1.5.0   | 2021-06-13 | Added FM/ADPCM panning sequence, drumkit panning, and removed unused subdata of ADPCM envelope. |
 | 1.4.0   | 2020-04-28 | Added ADPCM drumkit instrument.                                                                 |
 | 1.3.0   | 2020-02-25 | Added ADPCM instrument.                                                                         |

--- a/data/specs/mod_specs_v1.6.1.md
+++ b/data/specs/mod_specs_v1.6.1.md
@@ -1,6 +1,6 @@
 # BambooTracker Module File (.btm) Format Specification
 
-v1.6.1 - 202Y-MM-DD
+v1.6.1 - 2023-01-21
 
 - All data are little endian.
 - Unless otherwise noted, character encoding of string is ASCII.
@@ -213,15 +213,17 @@ After this, repeat parameters in the table below for each operator.
 
 ### ADPCM sample
 
-| Type      | Field         | Description                                              |
-| --------- | ------------- | -------------------------------------------------------- |
-| uint8     | Index         | Sample index number.                                     |
-| uint32    | Offset        | Relative offset to end of the sample block.              |
-| uint8     | Root key      | Root key number.                                         |
-| uint16    | Root delta-N  | Delta-N (sample rate) in root key.                       |
-| uint8     | Repeat flag   | If bit 0 is set, this ADPCM sample is played repeatedly. |
-| uint32    | Sample length | Length of ADPCM sample.                                  |
-| uint8 x N | Sample        | Raw ADPCM sample is stored.                              |
+| Type      | Field                   | Description                                                 |
+| --------- | ----------------------- | ----------------------------------------------------------- |
+| uint8     | Index                   | Sample index number.                                        |
+| uint32    | Offset                  | Relative offset to end of the sample block.                 |
+| uint8     | Root key                | Root key number.                                            |
+| uint16    | Root delta-N            | Delta-N (sample rate) in root key.                          |
+| uint8     | Repeat flag             | If bit 0 is set, this ADPCM sample is played repeatedly.    |
+| uint32    | Sample length           | Length of ADPCM sample.                                     |
+| uint8 x N | Sample                  | Raw ADPCM sample is stored.                                 |
+| uint16    | Repeat beginning offset | Offset of repeat beginning point from sample start address. |
+| uint16    | Repeat ending offset    | Offset of repeat ending point from sample start address.    |
 
 ### Sequence
 
@@ -515,7 +517,7 @@ Key event details:
 
 | Version | Date       | Detail                                                                                                                           |
 | ------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| 1.6.1   | 202Y-MM-DD | Add key cut.                                                                                                                     |
+| 1.6.1   | 2023-01-21 | Add key cut and ADPCM sample repeat range settings.                                                                              |
 | 1.6.0   | 2021-06-13 | Added track visibility, key signature, FM/ADPCM panning sequence, drumkit panning, and removed unused subdata of ADPCM envelope. |
 | 1.5.0   | 2020-04-28 | Added ADPCM drumkit instrument.                                                                                                  |
 | 1.4.1   | 2020-03-01 | Added bookmark section.                                                                                                          |


### PR DESCRIPTION
This is an experimantal feature. See #465 for more infomation on "partial repeat."

You can set repeat start and stop points when "repeat" is enabled in ADPCM Sample editor. There are two spinboxes beside "repeat" checkboxs: Repeat start point and Repeat stop point. The value of spinboxes can be changed by 64.
In the waveform view, repeat start point is displayed as a purple line, and repeat stop point is drawn by violet line. Currently it is not possible to move repeat points by dragging it on the sample view.

<img src="https://user-images.githubusercontent.com/26477882/213849268-62cd3e73-289c-4c45-8d76-bbb3b431c024.png" alt="Sample editor" width=400/>

As mentioned in #465, partial repeat requires rewriting start address after the start of sample syntesis. In BambooTracker, the rewrite is done at the next tick of the note on; PMD does it at an earlier timing, so it is partially incompatible.