### PR TITLE
Fix compiler error with clang15

### DIFF
--- a/BambooTracker/gui/order_list_editor/order_list_panel.cpp
+++ b/BambooTracker/gui/order_list_editor/order_list_panel.cpp
@@ -709,9 +709,8 @@ void OrderListPanel::drawBorders(int maxWidth)
 	QPainter painter(&backPixmap_);
 	painter.setPen(palette_->odrBorderColor);
 	painter.drawLine(rowNumWidth_, 0, rowNumWidth_, backPixmap_.height());
-	for (int x = rowNumWidth_ + trackWidth_, trackVisIdx = leftTrackVisIdx_; x <= maxWidth; ++trackVisIdx) {
+	for (int x = rowNumWidth_ + trackWidth_; x <= maxWidth; x += trackWidth_) {
 		painter.drawLine(x, 0, x, backPixmap_.height());
-		x += trackWidth_;
 	}
 }
 


### PR DESCRIPTION
This fixes the following compiler error since -Werror is used:

```
gui/order_list_editor/order_list_panel.cpp:712:43: error: variable 'trackVisIdx' set but not used [-Werror,-Wunused-but-set-variable]
        for (int x = rowNumWidth_ + trackWidth_, trackVisIdx = leftTrackVisIdx_; x <= maxWidth; ++trackVisIdx) {
                                                 ^
1 error generated.
```