### PR TITLE
Fix nix-user-chroot in Linux release artefact

### DIFF
--- a/scripts/build_nixpkgs_local.nix
+++ b/scripts/build_nixpkgs_local.nix
@@ -21,9 +21,24 @@ let
     });
   };
   pkgs = import <nixpkgs> { config = { inherit packageOverrides; }; };
+  nix-bundle-patched = pkgs.nix-bundle.overrideAttrs (oa: {
+    # https://github.com/matthewbauer/nix-bundle/pull/98
+    patches = (oa.patches or []) ++ [
+      (pkgs.fetchpatch {
+        name = "0001-nix-bundle-nix-user-chroot-Link-libgcc_s.so.1.patch";
+        url = "https://github.com/matthewbauer/nix-bundle/pull/98/commits/c047b32dc4d004189c3564eae458aecc5d28f25d.patch";
+        hash = "sha256-VR45xP7rw3GzIrkznHLPPf9OIVZnlnezUjCKhfQJ47s=";
+      })
+    ];
+    # https://github.com/matthewbauer/nix-bundle/issues/72
+    postInstall = (oa.postInstall or "") + ''
+      substituteInPlace $out/share/nix-bundle/nix-user-chroot/Makefile \
+        --replace 'g++' 'g++ -static-libstdc++'
+    '';
+  });
 in {
   build = pkgs.bambootracker;
-  bundle = (import "${pkgs.nix-bundle}/share/nix-bundle/default.nix" {}).nix-bootstrap {
+  bundle = (import "${nix-bundle-patched}/share/nix-bundle/default.nix" {}).nix-bootstrap {
     target = pkgs.bambootracker;
     run = "/bin/BambooTracker";
   };


### PR DESCRIPTION
Closes #498

Will need a test-release for the build automation machine to spit out a testable release artefact, haven't done that yet.