### PR TITLE
change strncpy to memcpy

### DIFF
--- a/BambooTracker/format/wopn_file.c
+++ b/BambooTracker/format/wopn_file.c
@@ -552,7 +552,7 @@ int WOPN_SaveBankToMem(WOPNFile *file, void *dest_mem, size_t length, uint16_t v
             {
                 if(length < 34)
                     return WOPN_ERR_UNEXPECTED_ENDING;
-                strncpy((char*)cursor, bankslots[i][j].bank_name, 32);
+                memcpy(cursor, bankslots[i][j].bank_name, 32);
                 cursor[32] = bankslots[i][j].bank_midi_lsb;
                 cursor[33] = bankslots[i][j].bank_midi_msb;
                 GO_FORWARD(34);


### PR DESCRIPTION
This should fix #505
strncpy may not null-terminate the string if the source string is exactly the length 32, memcpy can be used if this do not matter.