### PR TITLE
Bump macOS 12

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,9 +58,9 @@ environment:
     #   DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-windows-xp-32bit.zip
     #   MAKE: mingw32-make
     #   RELEASE_BUILD: true
-    # macOS Big Sur
+    # macOS Monterey
     - APPVEYOR_JOB_NAME: for macOS
-      APPVEYOR_BUILD_WORKER_IMAGE: macos-bigsur
+      APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
       PLATFORM: macos
       DEST: BambooTracker-v$APPVEYOR_BUILD_VERSION-dev-macos-64bit.zip
       MAKE: make
@@ -107,7 +107,7 @@ before_build:
       brew install curl
       brew install pkg-config jack p7zip
 
-      export PATH="$HOME/Qt/6.4/macos/bin:$PATH"
+      export PATH="$HOME/Qt/6.5/macos/bin:$PATH"
       export PKG_CONFIG_PATH="/usr/local/opt/jack/lib/pkgconfig"${PKG_CONFIG_PATH:+':'}$PKG_CONFIG_PATH
 
 # to run your custom scripts instead of automatic MSBuild

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -119,7 +119,7 @@ build_script:
       Invoke-Expression ($env:MAKE + " qmake_all")
       Invoke-Expression ($env:MAKE + " -j2")
   - sh: |
-      qmake Project.pro PREFIX="$APPVEYOR_BUILD_FOLDER"/target CONFIG-=release CONFIG+=debug CONFIG+=console CONFIG+=nostrip CONFIG+=install_flat CONFIG+=use_jack
+      qmake Project.pro PREFIX="$APPVEYOR_BUILD_FOLDER"/target CONFIG-=release CONFIG+=debug CONFIG+=console CONFIG+=nostrip CONFIG+=install_flat CONFIG+=use_jack CONFIG+=no_warnings_are_errors
       $MAKE qmake_all
       $MAKE -j2
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -96,10 +96,6 @@ jobs:
         run: |
           export HOMEBREW_NO_INSTALL_CLEANUP=1
           brew update
-          # JACK implies brew link python-3.10, fails due to shipped python binaries
-          brew unlink python@3.10 python@3.11
-          brew link --overwrite python@3.10 python@3.11
-          brew upgrade --force python@3.10 python@3.11
           brew install pkg-config jack coreutils
 
       ## End macOS-specific steps

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-12
 
     steps:
       - name: Identify build type.
@@ -75,7 +75,7 @@ jobs:
       ## macOS-specific steps
 
       - name: Pin Xcode version
-        run: sudo xcode-select -s "/Applications/Xcode_13.2.1.app"
+        run: sudo xcode-select -s "/Applications/Xcode_14.2.app"
 
       # Cache Qt installations, very costly & flakey to fetch
       - name: Fetching Qt cache.

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,7 +31,7 @@ env:
   QT_TOOLCHAIN: clang_64
   QT_MODULES: qtbase qttools qttranslations qt5compat qtdeclarative
   QT_INSTALLBASE: ${{ github.workspace }}/Qt/
-  QMAKE_EXTRA_ARGUMENTS: CONFIG+=install_flat CONFIG+=use_jack
+  QMAKE_EXTRA_ARGUMENTS: CONFIG+=install_flat CONFIG+=use_jack CONFIG+=no_warnings_are_errors
 
 jobs:
   build:


### PR DESCRIPTION
[GitHub runners for macOS 11 was deprecated](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal), so we need to update to 12.

At the same time, the image used by Appveyor is changed to 12. In addition, the version of Qt will be updated.