### PR TITLE
Bump macOS 13

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,9 +58,9 @@ environment:
     #   DEST: BambooTracker-v%APPVEYOR_BUILD_VERSION%-windows-xp-32bit.zip
     #   MAKE: mingw32-make
     #   RELEASE_BUILD: true
-    # macOS Monterey
+    # macOS Ventura
     - APPVEYOR_JOB_NAME: for macOS
-      APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
+      APPVEYOR_BUILD_WORKER_IMAGE: macos-ventura
       PLATFORM: macos
       DEST: BambooTracker-v$APPVEYOR_BUILD_VERSION-dev-macos-64bit.zip
       MAKE: make
@@ -107,7 +107,7 @@ before_build:
       brew install curl
       brew install pkg-config jack p7zip
 
-      export PATH="$HOME/Qt/6.5/macos/bin:$PATH"
+      export PATH="$HOME/Qt/6.6/macos/bin:$PATH"
       export PKG_CONFIG_PATH="/usr/local/opt/jack/lib/pkgconfig"${PKG_CONFIG_PATH:+':'}$PKG_CONFIG_PATH
 
 # to run your custom scripts instead of automatic MSBuild

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - name: Identify build type.
@@ -75,7 +75,7 @@ jobs:
       ## macOS-specific steps
 
       - name: Pin Xcode version
-        run: sudo xcode-select -s "/Applications/Xcode_14.2.app"
+        run: sudo xcode-select -s "/Applications/Xcode_15.2.app"
 
       # Cache Qt installations, very costly & flakey to fetch
       - name: Fetching Qt cache.


### PR DESCRIPTION
According to actions/runner-images#10721, GitHub runners for macOS 12 will be removed by December 3rd, 2024, so we need to update to 13.


We will also update the macOS image and Qt using in Appveyor.