### PR TITLE
Overflow paste option

### DIFF
--- a/BambooTracker/bamboo_tracker.cpp
+++ b/BambooTracker/bamboo_tracker.cpp
@@ -2698,14 +2698,14 @@ namespace
 {
 std::vector<std::vector<std::string>> arrangePatternDataCells(
 		size_t trackCnt, size_t ptnSize, int beginTrack, int beginColmn, int beginStep,
-		const std::vector<std::vector<std::string>>& cells)
+		const std::vector<std::vector<std::string>>& cells, bool overflow)
 {
 	size_t w = (trackCnt - static_cast<size_t>(beginTrack) - 1) * 11
 			   + (11 - static_cast<size_t>(beginColmn));
 	size_t h = ptnSize - static_cast<size_t>(beginStep);
 
 	size_t width = std::min(cells.at(0).size(), w);
-	size_t height = std::min(cells.size(), h);
+	size_t height = overflow ? cells.size() : std::min(cells.size(), h);
 
 	std::vector<std::vector<std::string>> d(height);
 	for (size_t i = 0; i < height; ++i) {
@@ -2716,37 +2716,39 @@ std::vector<std::vector<std::string>> arrangePatternDataCells(
 }
 
 void BambooTracker::pastePatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder, int beginStep,
-									  const std::vector<std::vector<std::string>>& cells)
+									  const std::vector<std::vector<std::string>>& cells, bool overflow)
 {
 	auto d = arrangePatternDataCells(songStyle_.trackAttribs.size(), getPatternSizeFromOrderNumber(songNum, beginOrder),
-									 beginTrack, beginColmn, beginStep, cells);
+									 beginTrack, beginColmn, beginStep, cells, overflow);
 	comMan_.invoke(std::make_unique<PasteCopiedDataToPatternCommand>(
 					   mod_, songNum, beginTrack, beginColmn, beginOrder, beginStep, std::move(d)));
 }
 
 void BambooTracker::pasteMixPatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder, int beginStep,
-										 const std::vector<std::vector<std::string> >& cells)
+										 const std::vector<std::vector<std::string> >& cells, bool overflow)
 {
 	auto d = arrangePatternDataCells(songStyle_.trackAttribs.size(), getPatternSizeFromOrderNumber(songNum, beginOrder),
-									 beginTrack, beginColmn, beginStep, cells);
+									 beginTrack, beginColmn, beginStep, cells, overflow);
 	comMan_.invoke(std::make_unique<PasteMixCopiedDataToPatternCommand>(
 					   mod_, songNum, beginTrack, beginColmn, beginOrder, beginStep, std::move(d)));
 }
 
 void BambooTracker::pasteOverwritePatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder,
-											   int beginStep, const std::vector<std::vector<std::string> >& cells)
+											   int beginStep, const std::vector<std::vector<std::string> >& cells,
+											   bool overflow)
 {
 	auto d = arrangePatternDataCells(songStyle_.trackAttribs.size(), getPatternSizeFromOrderNumber(songNum, beginOrder),
-									 beginTrack, beginColmn, beginStep, cells);
+									 beginTrack, beginColmn, beginStep, cells, overflow);
 	comMan_.invoke(std::make_unique<PasteOverwriteCopiedDataToPatternCommand>(
 					   mod_, songNum, beginTrack, beginColmn, beginOrder, beginStep, std::move(d)));
 }
 
 void BambooTracker::pasteInsertPatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder,
-											int beginStep, const std::vector<std::vector<std::string> >& cells)
+											int beginStep, const std::vector<std::vector<std::string> >& cells,
+											bool overflow)
 {
 	auto d = arrangePatternDataCells(songStyle_.trackAttribs.size(), getPatternSizeFromOrderNumber(songNum, beginOrder),
-									 beginTrack, beginColmn, beginStep, cells);
+									 beginTrack, beginColmn, beginStep, cells, overflow);
 	comMan_.invoke(std::make_unique<PasteInsertCopiedDataToPatternCommand>(
 					   mod_, songNum, beginTrack, beginColmn, beginOrder, beginStep, std::move(d)));
 }

--- a/BambooTracker/bamboo_tracker.cpp
+++ b/BambooTracker/bamboo_tracker.cpp
@@ -2744,11 +2744,10 @@ void BambooTracker::pasteOverwritePatternCells(int songNum, int beginTrack, int 
 }
 
 void BambooTracker::pasteInsertPatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder,
-											int beginStep, const std::vector<std::vector<std::string> >& cells,
-											bool overflow)
+											int beginStep, const std::vector<std::vector<std::string> >& cells)
 {
 	auto d = arrangePatternDataCells(songStyle_.trackAttribs.size(), getPatternSizeFromOrderNumber(songNum, beginOrder),
-									 beginTrack, beginColmn, beginStep, cells, overflow);
+									 beginTrack, beginColmn, beginStep, cells, false);
 	comMan_.invoke(std::make_unique<PasteInsertCopiedDataToPatternCommand>(
 					   mod_, songNum, beginTrack, beginColmn, beginOrder, beginStep, std::move(d)));
 }

--- a/BambooTracker/bamboo_tracker.hpp
+++ b/BambooTracker/bamboo_tracker.hpp
@@ -521,8 +521,7 @@ public:
 									int beginStep, const std::vector<std::vector<std::string>>& cells,
 									bool overflow);
 	void pasteInsertPatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder,
-								 int beginStep, const std::vector<std::vector<std::string>>& cells,
-								 bool overflow);
+								 int beginStep, const std::vector<std::vector<std::string>>& cells);
 	void erasePatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder, int beginStep,
 						   int endTrack, int endColmn, int endStep);
 	void transposeNoteInPattern(int songNum, int beginTrack, int beginOrder, int beginStep,

--- a/BambooTracker/bamboo_tracker.hpp
+++ b/BambooTracker/bamboo_tracker.hpp
@@ -512,13 +512,17 @@ public:
 	///		3: effect ID
 	///		4: effect value
 	void pastePatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder, int beginStep,
-						   const std::vector<std::vector<std::string>>& cells);
+						   const std::vector<std::vector<std::string>>& cells,
+						   bool overflow);
 	void pasteMixPatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder, int beginStep,
-							  const std::vector<std::vector<std::string>>& cells);
+							  const std::vector<std::vector<std::string>>& cells,
+							  bool overflow);
 	void pasteOverwritePatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder,
-									int beginStep, const std::vector<std::vector<std::string>>& cells);
+									int beginStep, const std::vector<std::vector<std::string>>& cells,
+									bool overflow);
 	void pasteInsertPatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder,
-								 int beginStep, const std::vector<std::vector<std::string>>& cells);
+								 int beginStep, const std::vector<std::vector<std::string>>& cells,
+								 bool overflow);
 	void erasePatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder, int beginStep,
 						   int endTrack, int endColmn, int endStep);
 	void transposeNoteInPattern(int songNum, int beginTrack, int beginOrder, int beginStep,

--- a/BambooTracker/command/pattern/paste_mix_copied_data_to_pattern_command.cpp
+++ b/BambooTracker/command/pattern/paste_mix_copied_data_to_pattern_command.cpp
@@ -48,11 +48,16 @@ void PasteMixCopiedDataToPatternCommand::redo()
 	auto& sng = mod_.lock()->getSong(song_);
 
 	int s = step_;
+	int o = order_;
 	for (const auto& row : cells_) {
 		int t = track_;
 		int c = col_;
 		for (const std::string& cell : row) {
-			Step& step = command_utils::getStep(sng, t, order_, s);
+			if (static_cast<size_t>(s) >= sng.getTrack(t).getPatternFromOrderNumber(o).getSize()) {
+				if (static_cast<size_t>(++o) < sng.getTrack(t).getOrderSize()) { s = 0; }
+				else { return; }
+			}
+			Step& step = command_utils::getStep(sng, t, o, s);
 			switch (c) {
 			case 0:
 			{

--- a/BambooTracker/command/pattern/paste_overwrite_copied_data_to_pattern_command.cpp
+++ b/BambooTracker/command/pattern/paste_overwrite_copied_data_to_pattern_command.cpp
@@ -48,11 +48,16 @@ void PasteOverwriteCopiedDataToPatternCommand::redo()
 	auto& sng = mod_.lock()->getSong(song_);
 
 	int s = step_;
+	int o = order_;
 	for (const auto& row : cells_) {
 		int t = track_;
 		int c = col_;
 		for (const std::string& cell : row) {
-			Step& st = command_utils::getStep(sng, t, order_, s);
+			if (static_cast<size_t>(s) >= sng.getTrack(t).getPatternFromOrderNumber(o).getSize()) {
+				if (static_cast<size_t>(++o) < sng.getTrack(t).getOrderSize()) { s = 0; }
+				else { return; }
+			}
+			Step& st = command_utils::getStep(sng, t, o, s);
 			switch (c) {
 			case 0:
 			{

--- a/BambooTracker/command/pattern/pattern_command_utils.cpp
+++ b/BambooTracker/command/pattern/pattern_command_utils.cpp
@@ -58,6 +58,10 @@ std::vector<std::vector<std::string>> getPreviousCells(Song& song, size_t w, siz
 		int c = beginColumn;
 		cells[i].resize(w);
 		for (size_t j = 0; j < w; ++j) {
+			if (static_cast<size_t>(s) >= song.getTrack(t).getPatternFromOrderNumber(beginOrder).getSize()) {
+				if (static_cast<size_t>(++beginOrder) < song.getTrack(t).getOrderSize()) { s = 0; }
+				else { return cells; }
+			}
 			Step& st = song.getTrack(t).getPatternFromOrderNumber(beginOrder).getStep(s);
 			std::string val;
 			switch (c) {
@@ -95,6 +99,10 @@ void restorePattern(Song& song, const std::vector<std::vector<std::string>>& cel
 		int t = beginTrack;
 		int c = beginColumn;
 		for (const std::string& cell : row) {
+			if (static_cast<size_t>(s) >= song.getTrack(t).getPatternFromOrderNumber(beginOrder).getSize()) {
+				if (static_cast<size_t>(++beginOrder) < song.getTrack(t).getOrderSize()) { s = 0; }
+				else { return; }
+			}
 			Step& st = song.getTrack(t).getPatternFromOrderNumber(beginOrder).getStep(s);
 			switch (c) {
 			case 0:		st.setNoteNumber(std::stoi(cell));			break;

--- a/BambooTracker/configuration.cpp
+++ b/BambooTracker/configuration.cpp
@@ -199,6 +199,7 @@ Configuration::Configuration()
 	fixJamVol_ = true;
 	muteHiddenTracks_ = true;
 	restoreTrackVis_ = false;
+	overflowPaste_ = false;
 
 	// Edit settings
 	pageJumpLength_ = 4;

--- a/BambooTracker/configuration.hpp
+++ b/BambooTracker/configuration.hpp
@@ -213,12 +213,14 @@ public:
 	bool getMuteHiddenTracks() const { return muteHiddenTracks_; }
 	void setRestoreTrackVisibility(bool enabled) { restoreTrackVis_ = enabled; }
 	bool getRestoreTrackVisibility() const { return restoreTrackVis_; }
+	void setOverflowPaste(bool enabled) { overflowPaste_ = enabled; }
+	bool getOverflowPaste() const { return overflowPaste_; }
 private:
 	bool warpCursor_, warpAcrossOrders_, showRowNumHex_, showPrevNextOrders_, backupModules_;
 	bool dontSelectOnDoubleClick_, reverseFMVolumeOrder_, moveCursorToRight_, retrieveChannelState_;
 	bool enableTranslation_, showFMDetuneSigned_, fill00ToEffectValue_, moveCursorHScroll_;
 	bool overwriteUnusedUnedited_, writeOnlyUsedSamples_, reflectInstNumChange_, fixJamVol_;
-	bool muteHiddenTracks_, restoreTrackVis_;
+	bool muteHiddenTracks_, restoreTrackVis_, overflowPaste_;
 
 	// Edit settings
 public:

--- a/BambooTracker/gui/configuration_dialog.cpp
+++ b/BambooTracker/gui/configuration_dialog.cpp
@@ -139,6 +139,8 @@ ConfigurationDialog::ConfigurationDialog(std::weak_ptr<Configuration> config, st
 		   tr("Automatically mute tracks when they are hidden."));
 	glfunc(18, configLocked->getRestoreTrackVisibility(),
 		   tr("Restore the previous track visibility on startup."));
+	glfunc(19, configLocked->getOverflowPaste(),
+		   tr("Move pasted pattern data outside the rows of the current frame to subsequent frames."));
 
 	// Edit settings
 	ui->pageJumpLengthSpinBox->setValue(static_cast<int>(configLocked->getPageJumpLength()));
@@ -455,6 +457,7 @@ void ConfigurationDialog::on_ConfigurationDialog_accepted()
 	configLocked->setFixJammingVolume(fromCheckState(ui->generalSettingsListWidget->item(16)->checkState()));
 	configLocked->setMuteHiddenTracks(fromCheckState(ui->generalSettingsListWidget->item(17)->checkState()));
 	configLocked->setRestoreTrackVisibility(fromCheckState(ui->generalSettingsListWidget->item(18)->checkState()));
+	configLocked->setOverflowPaste(fromCheckState(ui->generalSettingsListWidget->item(19)->checkState()));
 
 	// Edit settings
 	configLocked->setPageJumpLength(static_cast<size_t>(ui->pageJumpLengthSpinBox->value()));

--- a/BambooTracker/gui/configuration_dialog.ui
+++ b/BambooTracker/gui/configuration_dialog.ui
@@ -258,6 +258,14 @@
               <enum>Unchecked</enum>
              </property>
             </item>
+			<item>
+             <property name="text">
+              <string>Overflow paste mode</string>
+             </property>
+             <property name="checkState">
+              <enum>Unchecked</enum>
+             </property>
+            </item>
            </widget>
           </item>
           <item row="1" column="0">

--- a/BambooTracker/gui/configuration_handler.cpp
+++ b/BambooTracker/gui/configuration_handler.cpp
@@ -219,6 +219,7 @@ bool saveConfiguration(std::weak_ptr<Configuration> config)
 		settings.setValue("fixJammingVolume",		configLocked->getFixJammingVolume());
 		settings.setValue("muteHiddenTracks",		configLocked->getMuteHiddenTracks());
 		settings.setValue("restoreTrackVisibility",	configLocked->getRestoreTrackVisibility());
+		settings.setValue("overflowPaste",			configLocked->getOverflowPaste());
 		settings.endGroup();
 
 		// Edit settings
@@ -374,6 +375,7 @@ bool loadConfiguration(std::weak_ptr<Configuration> config)
 		configLocked->setFixJammingVolume(settings.value("fixJammingVolume", configLocked->getFixJammingVolume()).toBool());
 		configLocked->setMuteHiddenTracks(settings.value("muteHiddenTracks", configLocked->getMuteHiddenTracks()).toBool());
 		configLocked->setRestoreTrackVisibility(settings.value("restoreTrackVisibility", configLocked->getRestoreTrackVisibility()).toBool());
+		configLocked->setOverflowPaste(settings.value("overflowPaste", configLocked->getOverflowPaste()).toBool());
 		if (settings.contains("autosetInstrument")) {	// For compatibility before v0.4.0
 			configLocked->setInstrumentMask(!settings.value("autosetInstrument").toBool());
 			settings.remove("autosetInstrument");

--- a/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
+++ b/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
@@ -1872,9 +1872,9 @@ void PatternEditorPanel::pasteCopiedCells(const PatternPosition& cursorPos)
 	if (config_->getPasteMode() == Configuration::PasteMode::Fill && selLeftAbovePos_.order != -1) {
 		cells = compandPasteCells(pos, cells);
 	}
-
+	bool overflow = config_->getOverflowPaste();
 	bt_->pastePatternCells(
-				curSongNum_, visTracks_.at(pos.trackVisIdx), pos.colInTrack, pos.order, pos.step, std::move(cells));
+				curSongNum_, visTracks_.at(pos.trackVisIdx), pos.colInTrack, pos.order, pos.step, std::move(cells), overflow);
 	comStack_.lock()->push(new PasteCopiedDataToPatternQtCommand(this));
 }
 
@@ -1886,9 +1886,9 @@ void PatternEditorPanel::pasteMixCopiedCells(const PatternPosition& cursorPos)
 	if (config_->getPasteMode() == Configuration::PasteMode::Fill && selLeftAbovePos_.order != -1) {
 		cells = compandPasteCells(pos, cells);
 	}
-
+	bool overflow = config_->getOverflowPaste();
 	bt_->pasteMixPatternCells(
-				curSongNum_, visTracks_.at(pos.trackVisIdx), pos.colInTrack, pos.order, pos.step, std::move(cells));
+				curSongNum_, visTracks_.at(pos.trackVisIdx), pos.colInTrack, pos.order, pos.step, std::move(cells), overflow);
 	comStack_.lock()->push(new PasteMixCopiedDataToPatternQtCommand(this));
 }
 
@@ -1900,9 +1900,9 @@ void PatternEditorPanel::pasteOverwriteCopiedCells(const PatternPosition& cursor
 	if (config_->getPasteMode() == Configuration::PasteMode::Fill && selLeftAbovePos_.order != -1) {
 		cells = compandPasteCells(pos, cells);
 	}
-
+	bool overflow = config_->getOverflowPaste();
 	bt_->pasteOverwritePatternCells(
-				curSongNum_, visTracks_.at(pos.trackVisIdx), pos.colInTrack, pos.order, pos.step, std::move(cells));
+				curSongNum_, visTracks_.at(pos.trackVisIdx), pos.colInTrack, pos.order, pos.step, std::move(cells), overflow);
 	comStack_.lock()->push(new PasteOverwriteCopiedDataToPatternQtCommand(this));
 }
 
@@ -1914,9 +1914,9 @@ void PatternEditorPanel::pasteInsertCopiedCells(const PatternPosition& cursorPos
 	if (config_->getPasteMode() == Configuration::PasteMode::Fill && selLeftAbovePos_.order != -1) {
 		cells = compandPasteCells(pos, cells);
 	}
-
+	bool overflow = config_->getOverflowPaste();
 	bt_->pasteInsertPatternCells(
-				curSongNum_, visTracks_.at(pos.trackVisIdx), pos.colInTrack, pos.order, pos.step, std::move(cells));
+				curSongNum_, visTracks_.at(pos.trackVisIdx), pos.colInTrack, pos.order, pos.step, std::move(cells), overflow);
 	comStack_.lock()->push(new PasteInsertCopiedDataToPatternQtCommand(this));
 }
 

--- a/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
+++ b/BambooTracker/gui/pattern_editor/pattern_editor_panel.cpp
@@ -1914,9 +1914,9 @@ void PatternEditorPanel::pasteInsertCopiedCells(const PatternPosition& cursorPos
 	if (config_->getPasteMode() == Configuration::PasteMode::Fill && selLeftAbovePos_.order != -1) {
 		cells = compandPasteCells(pos, cells);
 	}
-	bool overflow = config_->getOverflowPaste();
+
 	bt_->pasteInsertPatternCells(
-				curSongNum_, visTracks_.at(pos.trackVisIdx), pos.colInTrack, pos.order, pos.step, std::move(cells), overflow);
+				curSongNum_, visTracks_.at(pos.trackVisIdx), pos.colInTrack, pos.order, pos.step, std::move(cells));
 	comStack_.lock()->push(new PasteInsertCopiedDataToPatternQtCommand(this));
 }
 


### PR DESCRIPTION
fixes #467 

Aimed to mimic behavior of overflow paste in Famitracker, e.g., works for all paste types except insert paste.
Configuration dialogue/description was copied from Dn-Famitracker. No translations added yet.