### PR TITLE
README: Change repology badge to 3 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ They thus offer the latest or in-development features and fixes, but are not opt
 
 ### Packages (macOS, Linux, BSD)
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/bambootracker.svg)](https://repology.org/project/bambootracker/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/bambootracker.svg?columns=3)](https://repology.org/project/bambootracker/versions)
 
 #### Nixpkgs (macOS, Linux)
 


### PR DESCRIPTION
Make the badge friendlier to read by parsing into 3 columns

Preview: https://github.com/luzpaz/BambooTracker/blob/luzpaz-patch-1/README.md#packages-macos-linux-bsd