### PR TITLE
Improve error handling on undo/redo

### DIFF
--- a/BambooTracker/BambooTracker.pro
+++ b/BambooTracker/BambooTracker.pro
@@ -260,6 +260,7 @@ HEADERS += \
     gui/command/order/order_commands_qt.hpp \
     gui/command/order/order_list_common_qt_command.hpp \
     gui/command/pattern/pattern_editor_common_qt_command.hpp \
+    gui/command_result_message_box.hpp \
     gui/dpi.hpp \
     gui/drop_detect_list_widget.hpp \
     gui/effect_description.hpp \
@@ -403,6 +404,7 @@ HEADERS += \
     gui/comment_edit_dialog.hpp \
     io/binary_container.hpp \
     utils.hpp \
+    vector_2d.hpp \
     version.hpp \
     command/pattern/interpolate_pattern_command.hpp \
     command/pattern/reverse_pattern_command.hpp \

--- a/BambooTracker/bamboo_tracker.hpp
+++ b/BambooTracker/bamboo_tracker.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2023 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -44,6 +24,7 @@
 #include "io/wav_container.hpp"
 #include "bamboo_tracker_defs.hpp"
 #include "enum_hash.hpp"
+#include "vector_2d.hpp"
 
 class Configuration;
 enum class EffectDisplayControl;
@@ -314,8 +295,8 @@ public:
 	void setCurrentStepNumber(int num);
 
 	// Undo-Redo
-	void undo();
-	void redo();
+	bool undo();
+	bool redo();
 	void clearCommandHistory();
 
 	// Jam mode
@@ -476,8 +457,7 @@ public:
 	void setOrderPatternDigit(int songNum, int trackNum, int orderNum, int patternNum, bool secondEntry);
 	void insertOrderBelow(int songNum, int orderNum);
 	void deleteOrder(int songNum, int orderNum);
-	void pasteOrderCells(int songNum, int beginTrack, int beginOrder,
-						 const std::vector<std::vector<std::string>>& cells);
+	bool pasteOrderCells(int songNum, int beginTrack, int beginOrder, const Vector2d<int>& cells);
 	void duplicateOrder(int songNum, int orderNum);
 	void MoveOrder(int songNum, int orderNum, bool isUp);
 	void clonePatterns(int songNum, int beginOrder, int beginTrack, int endOrder, int endTrack);
@@ -511,18 +491,15 @@ public:
 	///		2: volume
 	///		3: effect ID
 	///		4: effect value
-	void pastePatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder, int beginStep,
-						   const std::vector<std::vector<std::string>>& cells,
-						   bool overflow);
-	void pasteMixPatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder, int beginStep,
-							  const std::vector<std::vector<std::string>>& cells,
-							  bool overflow);
-	void pasteOverwritePatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder,
-									int beginStep, const std::vector<std::vector<std::string>>& cells,
-									bool overflow);
-	void pasteInsertPatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder,
-								 int beginStep, const std::vector<std::vector<std::string>>& cells);
-	void erasePatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder, int beginStep,
+	bool pastePatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder, int beginStep,
+						   const Vector2d<std::string>& cells, bool overflow);
+	bool pasteMixPatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder, int beginStep,
+							  const Vector2d<std::string>& cells, bool overflow);
+	bool pasteOverwritePatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder,
+									int beginStep, const Vector2d<std::string>& cells, bool overflow);
+	bool pasteInsertPatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder,
+								 int beginStep, const Vector2d<std::string>& cells);
+	bool erasePatternCells(int songNum, int beginTrack, int beginColmn, int beginOrder, int beginStep,
 						   int endTrack, int endColmn, int endStep);
 	void transposeNoteInPattern(int songNum, int beginTrack, int beginOrder, int beginStep,
 								int endTrack, int endStep, int semitone);

--- a/BambooTracker/command/abstract_command.hpp
+++ b/BambooTracker/command/abstract_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -32,8 +12,8 @@ class AbstractCommand
 public:
 	AbstractCommand(CommandId id) : id_(id) {}
 	virtual ~AbstractCommand() = default;
-	virtual void redo() = 0;
-	virtual void undo() = 0;
+	virtual bool redo() = 0;
+	virtual bool undo() = 0;
 	inline CommandId getID() const noexcept { return id_; }
 	virtual bool mergeWith(const AbstractCommand* other)
 	{

--- a/BambooTracker/command/command_manager.hpp
+++ b/BambooTracker/command/command_manager.hpp
@@ -1,31 +1,11 @@
 /*
- * Copyright (C) 2018-2021 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
 
-#include <stack>
+#include <deque>
 #include <memory>
 #include "abstract_command.hpp"
 
@@ -34,11 +14,11 @@ class CommandManager
 public:
 	using CommandIPtr = std::unique_ptr<AbstractCommand>;
 
-	void invoke(CommandIPtr command);
-	void undo();
-	void redo();
+	bool invoke(CommandIPtr command);
+	bool undo();
+	bool redo();
 	void clear();
 
 private:
-	std::stack<CommandIPtr> undoStack_, redoStack_;
+	std::deque<CommandIPtr> undoStack_, redoStack_;
 };

--- a/BambooTracker/command/instrument/add_instrument_command.cpp
+++ b/BambooTracker/command/instrument/add_instrument_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "add_instrument_command.hpp"
@@ -45,13 +25,15 @@ AddInstrumentCommand::AddInstrumentCommand(std::weak_ptr<InstrumentsManager> man
 {
 }
 
-void AddInstrumentCommand::redo()
+bool AddInstrumentCommand::redo()
 {
 	if (inst_) manager_.lock()->addInstrument(inst_->clone());
 	else manager_.lock()->addInstrument(num_, type_, name_);
+	return true;
 }
 
-void AddInstrumentCommand::undo()
+bool AddInstrumentCommand::undo()
 {
 	manager_.lock()->removeInstrument(num_);
+	return true;
 }

--- a/BambooTracker/command/instrument/add_instrument_command.hpp
+++ b/BambooTracker/command/instrument/add_instrument_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -38,8 +18,8 @@ public:
 						 int num, InstrumentType type, const std::string& name);
 	AddInstrumentCommand(std::weak_ptr<InstrumentsManager> manager,
 						 std::unique_ptr<AbstractInstrument> inst);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<InstrumentsManager> manager_;

--- a/BambooTracker/command/instrument/change_instrument_name_command.cpp
+++ b/BambooTracker/command/instrument/change_instrument_name_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "change_instrument_name_command.hpp"
@@ -35,12 +15,14 @@ ChangeInstrumentNameCommand::ChangeInstrumentNameCommand(std::weak_ptr<Instrumen
 	oldName_ = manager_.lock()->getInstrumentName(instNum_);
 }
 
-void ChangeInstrumentNameCommand::redo()
+bool ChangeInstrumentNameCommand::redo()
 {
 	manager_.lock()->setInstrumentName(instNum_, newName_);
+	return true;
 }
 
-void ChangeInstrumentNameCommand::undo()
+bool ChangeInstrumentNameCommand::undo()
 {
 	manager_.lock()->setInstrumentName(instNum_, oldName_);
+	return true;
 }

--- a/BambooTracker/command/instrument/change_instrument_name_command.hpp
+++ b/BambooTracker/command/instrument/change_instrument_name_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -35,8 +15,8 @@ class ChangeInstrumentNameCommand final : public AbstractCommand
 public:
 	ChangeInstrumentNameCommand(std::weak_ptr<InstrumentsManager> manager,
 								int num, const std::string& name);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<InstrumentsManager> manager_;

--- a/BambooTracker/command/instrument/clone_instrument_command.cpp
+++ b/BambooTracker/command/instrument/clone_instrument_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "clone_instrument_command.hpp"
@@ -34,12 +14,14 @@ cloneInstrumentCommand::cloneInstrumentCommand(std::weak_ptr<InstrumentsManager>
 {
 }
 
-void cloneInstrumentCommand::redo()
+bool cloneInstrumentCommand::redo()
 {
 	manager_.lock()->cloneInstrument(cloneInstNum_, refInstNum_);
+	return true;
 }
 
-void cloneInstrumentCommand::undo()
+bool cloneInstrumentCommand::undo()
 {
 	manager_.lock()->removeInstrument(cloneInstNum_);
+	return true;
 }

--- a/BambooTracker/command/instrument/clone_instrument_command.hpp
+++ b/BambooTracker/command/instrument/clone_instrument_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -33,8 +13,8 @@ class cloneInstrumentCommand final : public AbstractCommand
 {
 public:
 	cloneInstrumentCommand(std::weak_ptr<InstrumentsManager> manager, int num, int refNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<InstrumentsManager> manager_;

--- a/BambooTracker/command/instrument/deep_clone_instrument_command.cpp
+++ b/BambooTracker/command/instrument/deep_clone_instrument_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "deep_clone_instrument_command.hpp"
@@ -34,12 +14,14 @@ DeepCloneInstrumentCommand::DeepCloneInstrumentCommand(std::weak_ptr<Instruments
 {
 }
 
-void DeepCloneInstrumentCommand::redo()
+bool DeepCloneInstrumentCommand::redo()
 {
 	manager_.lock()->deepCloneInstrument(cloneInstNum_, refInstNum_);
+	return true;
 }
 
-void DeepCloneInstrumentCommand::undo()
+bool DeepCloneInstrumentCommand::undo()
 {
 	manager_.lock()->removeInstrument(cloneInstNum_);
+	return true;
 }

--- a/BambooTracker/command/instrument/deep_clone_instrument_command.hpp
+++ b/BambooTracker/command/instrument/deep_clone_instrument_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -33,8 +13,8 @@ class DeepCloneInstrumentCommand final : public AbstractCommand
 {
 public:
 	DeepCloneInstrumentCommand(std::weak_ptr<InstrumentsManager> manager, int num, int refNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<InstrumentsManager> manager_;

--- a/BambooTracker/command/instrument/remove_instrument_command.cpp
+++ b/BambooTracker/command/instrument/remove_instrument_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "remove_instrument_command.hpp"
@@ -32,12 +12,14 @@ RemoveInstrumentCommand::RemoveInstrumentCommand(std::weak_ptr<InstrumentsManage
 {
 }
 
-void RemoveInstrumentCommand::redo()
+bool RemoveInstrumentCommand::redo()
 {
 	inst_ = manager_.lock()->removeInstrument(number_);
+	return true;
 }
 
-void RemoveInstrumentCommand::undo()
+bool RemoveInstrumentCommand::undo()
 {
 	manager_.lock()->addInstrument(inst_.release());
+	return true;
 }

--- a/BambooTracker/command/instrument/remove_instrument_command.hpp
+++ b/BambooTracker/command/instrument/remove_instrument_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -34,8 +14,8 @@ class RemoveInstrumentCommand final : public AbstractCommand
 {
 public:
 	RemoveInstrumentCommand(std::weak_ptr<InstrumentsManager> manager, int number);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<InstrumentsManager> manager_;

--- a/BambooTracker/command/instrument/swap_instruments_command.cpp
+++ b/BambooTracker/command/instrument/swap_instruments_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2020 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "swap_instruments_command.hpp"
@@ -38,16 +18,18 @@ SwapInstrumentsCommand::SwapInstrumentsCommand(std::weak_ptr<InstrumentsManager>
 {
 }
 
-void SwapInstrumentsCommand::redo()
+bool SwapInstrumentsCommand::redo()
 {
 	manager_.lock()->swapInstruments(inst1Num_, inst2Num_);
 	if (patternChange_) swapInstrumentsInPatterns();
+	return true;
 }
 
-void SwapInstrumentsCommand::undo()
+bool SwapInstrumentsCommand::undo()
 {
 	manager_.lock()->swapInstruments(inst1Num_, inst2Num_);
 	if (patternChange_) swapInstrumentsInPatterns();
+	return true;
 }
 
 void SwapInstrumentsCommand::swapInstrumentsInPatterns()

--- a/BambooTracker/command/instrument/swap_instruments_command.hpp
+++ b/BambooTracker/command/instrument/swap_instruments_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2020 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -35,8 +15,8 @@ class SwapInstrumentsCommand final : public AbstractCommand
 public:
 	SwapInstrumentsCommand(std::weak_ptr<InstrumentsManager> manager, std::weak_ptr<Module> mod,
 						   int inst1, int inst2, int song, bool patternChange);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<InstrumentsManager> manager_;

--- a/BambooTracker/command/order/clone_order_command.cpp
+++ b/BambooTracker/command/order/clone_order_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "clone_order_command.hpp"
@@ -30,7 +10,7 @@ CloneOrderCommand::CloneOrderCommand(std::weak_ptr<Module> mod, int songNum, int
 {
 }
 
-void CloneOrderCommand::redo()
+bool CloneOrderCommand::redo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 	sng.insertOrderBelow(order_);
@@ -40,9 +20,10 @@ void CloneOrderCommand::redo()
 		track.registerPatternToOrder(order_ + 1, track.getPatternFromOrderNumber(order_).getNumber());
 		track.registerPatternToOrder(order_ + 1, track.clonePattern(track.getOrderInfo(order_).patten));
 	}
+	return true;
 }
 
-void CloneOrderCommand::undo()
+bool CloneOrderCommand::undo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 	for (auto& t : sng.getTrackAttributes()) {
@@ -50,4 +31,5 @@ void CloneOrderCommand::undo()
 		if (p.getUsedCount() == 1) p.clear();
 	}
 	sng.deleteOrder(order_ + 1);
+	return true;
 }

--- a/BambooTracker/command/order/clone_order_command.hpp
+++ b/BambooTracker/command/order/clone_order_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -34,8 +14,8 @@ class CloneOrderCommand final : public AbstractCommand
 {
 public:
 	CloneOrderCommand(std::weak_ptr<Module> mod, int songNum, int orderNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/order/clone_patterns_command.cpp
+++ b/BambooTracker/command/order/clone_patterns_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "clone_patterns_command.hpp"
@@ -44,7 +24,7 @@ ClonePatternsCommand::ClonePatternsCommand(std::weak_ptr<Module> mod, int songNu
 	}
 }
 
-void ClonePatternsCommand::redo()
+bool ClonePatternsCommand::redo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 	for (int o = bOrder_; o <= eOrder_; ++o) {
@@ -53,9 +33,10 @@ void ClonePatternsCommand::redo()
 			track.registerPatternToOrder(o, track.clonePattern(track.getOrderInfo(o).patten));
 		}
 	}
+	return true;
 }
 
-void ClonePatternsCommand::undo()
+bool ClonePatternsCommand::undo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 	for (int o = bOrder_; o <= eOrder_; ++o) {
@@ -68,4 +49,5 @@ void ClonePatternsCommand::undo()
 						prevOdrs_.at(static_cast<size_t>(o - bOrder_)).at(static_cast<size_t>(t - bTrack_)).patten);
 		}
 	}
+	return true;
 }

--- a/BambooTracker/command/order/clone_patterns_command.hpp
+++ b/BambooTracker/command/order/clone_patterns_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -35,8 +15,8 @@ class ClonePatternsCommand final : public AbstractCommand
 public:
 	ClonePatternsCommand(std::weak_ptr<Module> mod, int songNum,
 						 int beginOrder, int beginTrack, int endOrder, int endTrack);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/order/delete_order_command.cpp
+++ b/BambooTracker/command/order/delete_order_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "delete_order_command.hpp"
@@ -31,16 +11,18 @@ DeleteOrderCommand::DeleteOrderCommand(std::weak_ptr<Module> mod, int songNum, i
 	prevOdr_ = mod_.lock()->getSong(songNum).getOrderData(orderNum);
 }
 
-void DeleteOrderCommand::redo()
+bool DeleteOrderCommand::redo()
 {
 	mod_.lock()->getSong(song_).deleteOrder(order_);
+	return true;
 }
 
-void DeleteOrderCommand::undo()
+bool DeleteOrderCommand::undo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 	sng.insertOrderBelow(order_ - 1);
 	for (const auto& t : prevOdr_) {
 		sng.getTrack(t.trackAttribute.number).registerPatternToOrder(t.order, t.patten);
 	}
+	return true;
 }

--- a/BambooTracker/command/order/delete_order_command.hpp
+++ b/BambooTracker/command/order/delete_order_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -34,8 +14,8 @@ class DeleteOrderCommand final : public AbstractCommand
 {
 public:
 	DeleteOrderCommand(std::weak_ptr<Module> mod, int songNum, int orderNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/order/duplicate_order_command.cpp
+++ b/BambooTracker/command/order/duplicate_order_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "duplicate_order_command.hpp"
@@ -30,7 +10,7 @@ DuplicateOrderCommand::DuplicateOrderCommand(std::weak_ptr<Module> mod, int song
 {
 }
 
-void DuplicateOrderCommand::redo()
+bool DuplicateOrderCommand::redo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 	sng.insertOrderBelow(order_);
@@ -38,9 +18,11 @@ void DuplicateOrderCommand::redo()
 		auto& track = sng.getTrack(t.number);
 		track.registerPatternToOrder(order_ + 1, track.getOrderInfo(order_).patten);
 	}
+	return true;
 }
 
-void DuplicateOrderCommand::undo()
+bool DuplicateOrderCommand::undo()
 {
 	mod_.lock()->getSong(song_).deleteOrder(order_ + 1);
+	return true;
 }

--- a/BambooTracker/command/order/duplicate_order_command.hpp
+++ b/BambooTracker/command/order/duplicate_order_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -33,8 +13,8 @@ class DuplicateOrderCommand : public AbstractCommand
 {
 public:
 	DuplicateOrderCommand(std::weak_ptr<Module> mod, int songNum, int orderNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/order/insert_order_below_command.cpp
+++ b/BambooTracker/command/order/insert_order_below_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "insert_order_below_command.hpp"
@@ -30,12 +10,14 @@ InsertOrderBelowCommand::InsertOrderBelowCommand(std::weak_ptr<Module> mod, int 
 {
 }
 
-void InsertOrderBelowCommand::redo()
+bool InsertOrderBelowCommand::redo()
 {
 	mod_.lock()->getSong(song_).insertOrderBelow(order_);
+	return true;
 }
 
-void InsertOrderBelowCommand::undo()
+bool InsertOrderBelowCommand::undo()
 {
 	mod_.lock()->getSong(song_).deleteOrder(order_ + 1);
+	return true;
 }

--- a/BambooTracker/command/order/insert_order_below_command.hpp
+++ b/BambooTracker/command/order/insert_order_below_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -33,8 +13,8 @@ class InsertOrderBelowCommand final : public AbstractCommand
 {
 public:
 	InsertOrderBelowCommand(std::weak_ptr<Module> mod, int songNum, int orderNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/order/move_order_command.cpp
+++ b/BambooTracker/command/order/move_order_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "move_order_command.hpp"
@@ -30,14 +10,16 @@ MoveOrderCommand::MoveOrderCommand(std::weak_ptr<Module> mod, int songNum, int o
 {
 }
 
-void MoveOrderCommand::redo()
+bool MoveOrderCommand::redo()
 {
 	swap();
+	return true;
 }
 
-void MoveOrderCommand::undo()
+bool MoveOrderCommand::undo()
 {
 	swap();
+	return true;
 }
 
 void MoveOrderCommand::swap()

--- a/BambooTracker/command/order/move_order_command.hpp
+++ b/BambooTracker/command/order/move_order_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -33,8 +13,8 @@ class MoveOrderCommand final : public AbstractCommand
 {
 public:
 	MoveOrderCommand(std::weak_ptr<Module> mod, int songNum, int orderNum, bool isUp);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/order/paste_copied_data_to_order_command.cpp
+++ b/BambooTracker/command/order/paste_copied_data_to_order_command.cpp
@@ -1,69 +1,61 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "paste_copied_data_to_order_command.hpp"
 #include "track.hpp"
 
-PasteCopiedDataToOrderCommand::PasteCopiedDataToOrderCommand(
-		std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginOrder,
-		const std::vector<std::vector<std::string>>& cells)
+PasteCopiedDataToOrderCommand::PasteCopiedDataToOrderCommand(std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginOrder,
+		const Vector2d<int>& cells)
 	: AbstractCommand(CommandId::PasteCopiedDataToOrder),
 	  mod_(mod),
 	  song_(songNum),
 	  track_(beginTrack),
 	  order_(beginOrder),
-	  cells_(cells)
+	  cells_(cells),
+	  prevCells_(cells.shape())
 {
-	auto& sng = mod.lock()->getSong(songNum);
-	for (size_t i = 0; i < cells.size(); ++i) {
-		prevCells_.emplace_back();
-		std::vector<OrderInfo> odrs = sng.getOrderData(beginOrder + static_cast<int>(i));
-		for (size_t j = 0; j < cells.at(i).size(); ++j) {
-			prevCells_.at(i).push_back(std::to_string(odrs.at(static_cast<size_t>(beginTrack) + j).patten));
+	const auto& sng = mod.lock()->getSong(songNum);
+
+	for (std::size_t i = 0; i < cells.rowSize(); ++i) {
+		const std::vector<OrderInfo> odrs = sng.getOrderData(beginOrder + static_cast<int>(i));
+		for (std::size_t j = 0; j < cells.columnSize(); ++j) {
+			prevCells_[i][j] = odrs.at(static_cast<std::size_t>(beginTrack) + j).patten;
 		}
 	}
 }
 
-void PasteCopiedDataToOrderCommand::redo()
+bool PasteCopiedDataToOrderCommand::redo()
 {
-	setCells(cells_);
+	try {
+		setCells(cells_);
+		return true;
+	}
+	catch (...) {
+		return false;
+	}
 }
 
-void PasteCopiedDataToOrderCommand::undo()
+bool PasteCopiedDataToOrderCommand::undo()
 {
-	setCells(prevCells_);
+	try {
+		setCells(prevCells_);
+		return true;
+	}
+	catch (...) {
+		return false;
+	}
 }
 
-void PasteCopiedDataToOrderCommand::setCells(const std::vector<std::vector<std::string>>& cells)
+void PasteCopiedDataToOrderCommand::setCells(const Vector2d<int>& cells)
 {
 	auto& sng = mod_.lock()->getSong(song_);
 
-	for (size_t i = 0; i < cells.size(); ++i) {
-		for (size_t j = 0; j < cells.at(i).size(); ++j) {
+	for (std::size_t i = 0; i < cells.rowSize(); ++i) {
+		for (std::size_t j = 0; j < cells.columnSize(); ++j) {
 			sng.getTrack(track_ + static_cast<int>(j))
-					.registerPatternToOrder(order_ + static_cast<int>(i), std::stoi(cells.at(i).at(j)));
+					.registerPatternToOrder(order_ + static_cast<int>(i), cells[i][j]);
 		}
 	}
 }

--- a/BambooTracker/command/order/paste_copied_data_to_order_command.hpp
+++ b/BambooTracker/command/order/paste_copied_data_to_order_command.hpp
@@ -1,49 +1,29 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <string>
 #include "../abstract_command.hpp"
 #include "module.hpp"
+#include "vector_2d.hpp"
 
 class PasteCopiedDataToOrderCommand final : public AbstractCommand
 {
 public:
 	PasteCopiedDataToOrderCommand(
 			std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginOrder,
-			const std::vector<std::vector<std::string>>& cells);
-	void redo() override;
-	void undo() override;
+			const Vector2d<int>& cells);
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;
 	int song_, track_, order_;
-	std::vector<std::vector<std::string>> cells_, prevCells_;
+	Vector2d<int> cells_, prevCells_;
 
-	void setCells(const std::vector<std::vector<std::string>>& cells);
+	void setCells(const Vector2d<int>& cells);
 };

--- a/BambooTracker/command/order/set_pattern_to_order_command.cpp
+++ b/BambooTracker/command/order/set_pattern_to_order_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "set_pattern_to_order_command.hpp"
@@ -40,15 +20,17 @@ SetPatternToOrderCommand::SetPatternToOrderCommand(std::weak_ptr<Module> mod, in
 {
 }
 
-void SetPatternToOrderCommand::redo()
+bool SetPatternToOrderCommand::redo()
 {
 	mod_.lock()->getSong(song_).getTrack(track_).registerPatternToOrder(order_, pattern_);
+	return true;
 }
 
-void SetPatternToOrderCommand::undo()
+bool SetPatternToOrderCommand::undo()
 {
 	mod_.lock()->getSong(song_).getTrack(track_).registerPatternToOrder(order_, prevPattern_);
 	isSecondEntry_ = true;	// Forced complete
+	return true;
 }
 
 bool SetPatternToOrderCommand::mergeWith(const AbstractCommand* other)

--- a/BambooTracker/command/order/set_pattern_to_order_command.hpp
+++ b/BambooTracker/command/order/set_pattern_to_order_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -34,8 +14,8 @@ class SetPatternToOrderCommand final : public AbstractCommand
 public:
 	SetPatternToOrderCommand(std::weak_ptr<Module> mod, int songNum, int trackNum,
 							 int orderNum, int patternNum, bool secondEntry);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 	bool mergeWith(const AbstractCommand* other) override;
 
 private:

--- a/BambooTracker/command/pattern/change_values_in_pattern_command.cpp
+++ b/BambooTracker/command/pattern/change_values_in_pattern_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2020-2021 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2020 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "change_values_in_pattern_command.hpp"
@@ -77,7 +57,7 @@ ChangeValuesInPatternCommand::ChangeValuesInPatternCommand(
 	}
 }
 
-void ChangeValuesInPatternCommand::redo()
+bool ChangeValuesInPatternCommand::redo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 	auto it = prevVals_.begin();
@@ -116,9 +96,10 @@ void ChangeValuesInPatternCommand::redo()
 			col %= Step::N_COLUMN;
 		}
 	}
+	return true;
 }
 
-void ChangeValuesInPatternCommand::undo()
+bool ChangeValuesInPatternCommand::undo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 	auto it = prevVals_.begin();
@@ -150,4 +131,5 @@ void ChangeValuesInPatternCommand::undo()
 			col %= Step::N_COLUMN;
 		}
 	}
+	return true;
 }

--- a/BambooTracker/command/pattern/change_values_in_pattern_command.hpp
+++ b/BambooTracker/command/pattern/change_values_in_pattern_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2020 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -36,8 +16,8 @@ public:
 	ChangeValuesInPatternCommand(std::weak_ptr<Module> mod, int songNum,
 								 int beginTrack, int beginColumn, int beginOrder, int beginStep,
 								 int endTrack, int endColumn, int endStep, int value, bool isFMReversed);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/pattern/delete_previous_step_command.cpp
+++ b/BambooTracker/command/pattern/delete_previous_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "delete_previous_step_command.hpp"
@@ -44,12 +24,13 @@ DeletePreviousStepCommand::DeletePreviousStepCommand(
 	}
 }
 
-void DeletePreviousStepCommand::redo()
+bool DeletePreviousStepCommand::redo()
 {
 	command_utils::getPattern(mod_, song_, track_, order_).deletePreviousStep(step_);
+	return true;
 }
 
-void DeletePreviousStepCommand::undo()
+bool DeletePreviousStepCommand::undo()
 {
 	auto& pt = command_utils::getPattern(mod_, song_, track_, order_);
 	pt.insertStep(step_ - 1);	// Insert previous step
@@ -60,4 +41,5 @@ void DeletePreviousStepCommand::undo()
 	for (int i = 0; i < Step::N_EFFECT; ++i) {
 		st.setEffect(i, prevEff_[i]);
 	}
+	return true;
 }

--- a/BambooTracker/command/pattern/delete_previous_step_command.hpp
+++ b/BambooTracker/command/pattern/delete_previous_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -35,8 +15,8 @@ class DeletePreviousStepCommand final : public AbstractCommand
 public:
 	DeletePreviousStepCommand(std::weak_ptr<Module> mod, int songNum, int trackNum,
 							  int orderNum, int stepNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/pattern/erase_cells_in_pattern_command.cpp
+++ b/BambooTracker/command/pattern/erase_cells_in_pattern_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "erase_cells_in_pattern_command.hpp"
@@ -38,44 +18,69 @@ EraseCellsInPatternCommand::EraseCellsInPatternCommand(
 	  bStep_(beginStep)
 {
 	auto& song = mod.lock()->getSong(songNum);
-	size_t h = static_cast<size_t>(endStep - beginStep + 1);
-	size_t w = command_utils::calculateColumnSize(beginTrack, beginColumn, endTrack, endColumn);
+	std::size_t h = static_cast<size_t>(endStep - beginStep + 1);
+	std::size_t w = command_utils::calculateColumnSize(beginTrack, beginColumn, endTrack, endColumn);
 	prevCells_ = command_utils::getPreviousCells(song, w, h, beginTrack, beginColumn, beginOrder, beginStep);
 }
 
-void EraseCellsInPatternCommand::redo()
+bool EraseCellsInPatternCommand::redo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 
-	int s = bStep_;
-	for (size_t i = 0; i < prevCells_.size(); ++i) {
-		int t = bTrack_;
-		int c = bCol_;
-		for (size_t j = 0; j < prevCells_.at(i).size(); ++j) {
-			Step& st = command_utils::getStep(sng, t, order_, s);
-			switch (c) {
-			case 0:		st.clearNoteNumber();		break;
-			case 1:		st.clearInstrumentNumber();	break;
-			case 2:		st.clearVolume();			break;
-			default:
-			{
-				int ec = c - 3;
-				int ei = ec / 2;
-				if (ec % 2) st.clearEffectValue(ei);
-				else st.clearEffectId(ei);
+	int stepIndex = bStep_;
+
+	for (std::size_t i = 0; i < prevCells_.rowSize(); ++i) {
+		int trackIndex = bTrack_;
+		int columnIndex = bCol_;
+
+		for (std::size_t j = 0; j < prevCells_.columnSize(); ++j) {
+			Step& st = command_utils::getStep(sng, trackIndex, order_, stepIndex);
+
+			switch (columnIndex) {
+			case 0:
+				st.clearNoteNumber();
+				break;
+
+			case 1:
+				st.clearInstrumentNumber();
+				break;
+
+			case 2:
+				st.clearVolume();
+				break;
+
+			default: {
+				int effectColumnIndex = columnIndex - 3;
+				int effectNumber = effectColumnIndex / 2;
+				if (effectColumnIndex % 2) {
+					// Effect value column.
+					st.clearEffectValue(effectNumber);
+				}
+				else {
+					// Effect ID column.
+					st.clearEffectId(effectNumber);
+				}
 				break;
 			}
 			}
 
-			t += (++c / Step::N_COLUMN);
-			c %= Step::N_COLUMN;
+			trackIndex += (++columnIndex / Step::N_COLUMN);
+			columnIndex %= Step::N_COLUMN;
 		}
 
-		++s;
+		++stepIndex;
 	}
+
+	return true;
 }
 
-void EraseCellsInPatternCommand::undo()
+bool EraseCellsInPatternCommand::undo()
 {
-	command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, bTrack_, bCol_, order_, bStep_);
+	try {
+		command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, bTrack_, bCol_, order_, bStep_);
+		return true;
+	}
+	catch (...) {
+		return false;
+	}
 }

--- a/BambooTracker/command/pattern/erase_cells_in_pattern_command.hpp
+++ b/BambooTracker/command/pattern/erase_cells_in_pattern_command.hpp
@@ -1,35 +1,15 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <string>
 #include "../abstract_command.hpp"
 #include "module.hpp"
+#include "vector_2d.hpp"
 
 class EraseCellsInPatternCommand final : public AbstractCommand
 {
@@ -37,11 +17,11 @@ public:
 	EraseCellsInPatternCommand(std::weak_ptr<Module> mod, int songNum,
 							   int beginTrack, int beginColumn, int beginOrder, int beginStep,
 							   int endTrack, int endColumn, int endStep);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;
 	int song_, bTrack_, bCol_, order_, bStep_;
-	std::vector<std::vector<std::string>> prevCells_;
+	Vector2d<std::string> prevCells_;
 };

--- a/BambooTracker/command/pattern/erase_effect_in_step_command.cpp
+++ b/BambooTracker/command/pattern/erase_effect_in_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "erase_effect_in_step_command.hpp"
@@ -39,12 +19,14 @@ EraseEffectInStepCommand::EraseEffectInStepCommand(
 	prevEff_ = command_utils::getStep(mod, songNum, trackNum, orderNum, stepNum).getEffect(n);
 }
 
-void EraseEffectInStepCommand::redo()
+bool EraseEffectInStepCommand::redo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).clearEffect(n_);
+	return true;
 }
 
-void EraseEffectInStepCommand::undo()
+bool EraseEffectInStepCommand::undo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).setEffect(n_, prevEff_);
+	return true;
 }

--- a/BambooTracker/command/pattern/erase_effect_in_step_command.hpp
+++ b/BambooTracker/command/pattern/erase_effect_in_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -35,8 +15,8 @@ class EraseEffectInStepCommand final : public AbstractCommand
 public:
 	EraseEffectInStepCommand(std::weak_ptr<Module> mod, int songNum, int trackNum,
 							 int orderNum, int stepNum, int n);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/pattern/erase_effect_value_in_step_command.cpp
+++ b/BambooTracker/command/pattern/erase_effect_value_in_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "erase_effect_value_in_step_command.hpp"
@@ -39,12 +19,14 @@ EraseEffectValueInStepCommand::EraseEffectValueInStepCommand(
 	prevVal_ = command_utils::getStep(mod, songNum, trackNum, orderNum, stepNum).getEffectValue(n);
 }
 
-void EraseEffectValueInStepCommand::redo()
+bool EraseEffectValueInStepCommand::redo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).clearEffectValue(n_);
+	return true;
 }
 
-void EraseEffectValueInStepCommand::undo()
+bool EraseEffectValueInStepCommand::undo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).setEffectValue(n_, prevVal_);
+	return true;
 }

--- a/BambooTracker/command/pattern/erase_effect_value_in_step_command.hpp
+++ b/BambooTracker/command/pattern/erase_effect_value_in_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -34,8 +14,8 @@ class EraseEffectValueInStepCommand final : public AbstractCommand
 public:
 	EraseEffectValueInStepCommand(std::weak_ptr<Module> mod, int songNum, int trackNum,
 								  int orderNum, int stepNum, int n);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/pattern/erase_instrument_in_step_command.cpp
+++ b/BambooTracker/command/pattern/erase_instrument_in_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "erase_instrument_in_step_command.hpp"
@@ -39,12 +19,14 @@ EraseInstrumentInStepCommand::EraseInstrumentInStepCommand(
 				.getInstrumentNumber();
 }
 
-void EraseInstrumentInStepCommand::redo()
+bool EraseInstrumentInStepCommand::redo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).clearInstrumentNumber();
+	return true;
 }
 
-void EraseInstrumentInStepCommand::undo()
+bool EraseInstrumentInStepCommand::undo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).setInstrumentNumber(prevInst_);
+	return true;
 }

--- a/BambooTracker/command/pattern/erase_instrument_in_step_command.hpp
+++ b/BambooTracker/command/pattern/erase_instrument_in_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -34,8 +14,8 @@ class EraseInstrumentInStepCommand final : public AbstractCommand
 public:
 	EraseInstrumentInStepCommand(std::weak_ptr<Module> mod, int songNum, int trackNum,
 								 int orderNum, int stepNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/pattern/erase_step_command.cpp
+++ b/BambooTracker/command/pattern/erase_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "erase_step_command.hpp"
@@ -44,12 +24,13 @@ EraseStepCommand::EraseStepCommand(
 	}
 }
 
-void EraseStepCommand::redo()
+bool EraseStepCommand::redo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).clear();
+	return true;
 }
 
-void EraseStepCommand::undo()
+bool EraseStepCommand::undo()
 {
 	Step& st = command_utils::getStep(mod_, song_, track_, order_, step_);
 	st.setNoteNumber(prevNote_);
@@ -58,4 +39,5 @@ void EraseStepCommand::undo()
 	for (int i = 0; i < Step::N_EFFECT; ++i) {
 		st.setEffect(i, prevEff_[i]);
 	}
+	return true;
 }

--- a/BambooTracker/command/pattern/erase_step_command.hpp
+++ b/BambooTracker/command/pattern/erase_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -34,8 +14,8 @@ class EraseStepCommand final : public AbstractCommand
 {
 public:
 	EraseStepCommand(std::weak_ptr<Module> mod, int songNum, int trackNum, int orderNum, int stepNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/pattern/erase_volume_in_step_command.cpp
+++ b/BambooTracker/command/pattern/erase_volume_in_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "erase_volume_in_step_command.hpp"
@@ -38,12 +18,14 @@ EraseVolumeInStepCommand::EraseVolumeInStepCommand(
 	prevVol_ = command_utils::getStep(mod, songNum, trackNum, orderNum, stepNum).getVolume();
 }
 
-void EraseVolumeInStepCommand::redo()
+bool EraseVolumeInStepCommand::redo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).clearVolume();
+	return true;
 }
 
-void EraseVolumeInStepCommand::undo()
+bool EraseVolumeInStepCommand::undo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).setVolume(prevVol_);
+	return true;
 }

--- a/BambooTracker/command/pattern/erase_volume_in_step_command.hpp
+++ b/BambooTracker/command/pattern/erase_volume_in_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -34,8 +14,8 @@ class EraseVolumeInStepCommand final : public AbstractCommand
 public:
 	EraseVolumeInStepCommand(std::weak_ptr<Module> mod, int songNum, int trackNum,
 							 int orderNum, int stepNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/pattern/expand_pattern_command.cpp
+++ b/BambooTracker/command/pattern/expand_pattern_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "expand_pattern_command.hpp"
@@ -38,65 +18,96 @@ ExpandPatternCommand::ExpandPatternCommand(
 	  bStep_(beginStep)
 {
 	auto& song = mod.lock()->getSong(songNum);
-	size_t h = static_cast<size_t>(endStep - beginStep + 1);
-	size_t w = command_utils::calculateColumnSize(beginTrack, beginColumn, endTrack, endColumn);
+	std::size_t h = static_cast<size_t>(endStep - beginStep + 1);
+	std::size_t w = command_utils::calculateColumnSize(beginTrack, beginColumn, endTrack, endColumn);
 	prevCells_ = command_utils::getPreviousCells(song, w, h, beginTrack, beginColumn, beginOrder, beginStep);
 }
 
-void ExpandPatternCommand::redo()
+bool ExpandPatternCommand::redo()
 {
-	auto& sng = mod_.lock()->getSong(song_);
+	auto& song = mod_.lock()->getSong(song_);
 
-	int s = bStep_;
-	for (size_t i = 0; i < prevCells_.size(); ++i) {
-		int t = bTrack_;
-		int c = bCol_;
-		for (size_t j = 0; j < prevCells_.at(i).size(); ++j) {
-			Step& st = command_utils::getStep(sng, t, order_, s);
-			switch (c) {
-			case 0:
-			{
-				if (i % 2) st.clearNoteNumber();
-				else st.setNoteNumber(std::stoi(prevCells_.at(i / 2).at(j)));
-				break;
-			}
-			case 1:
-			{
-				if (i % 2) st.clearInstrumentNumber();
-				else st.setInstrumentNumber(std::stoi(prevCells_.at(i / 2).at(j)));
-				break;
-			}
-			case 2:
-			{
-				if (i % 2) st.clearVolume();
-				else st.setVolume(std::stoi(prevCells_.at(i / 2).at(j)));
-				break;
-			}
-			default:
-			{
-				int ec = c - 3;
-				int ei = ec / 2;
-				if (ec % 2) {
-					if (i % 2) st.clearEffectValue(ei);
-					else st.setEffectValue(ei, std::stoi(prevCells_.at(i / 2).at(j)));
+	int stepIndex = bStep_;
+	for (std::size_t i = 0; i < prevCells_.rowSize(); ++i) {
+		int trackIndex = bTrack_;
+		int columnIndex = bCol_;
+
+		for (std::size_t j = 0; j < prevCells_.columnSize(); ++j) {
+			Step& step = command_utils::getStep(song, trackIndex, order_, stepIndex);
+
+			switch (columnIndex) {
+			case 0: {
+				if (i % 2) {
+					step.clearNoteNumber();
 				}
 				else {
-					if (i % 2) st.clearEffectId(ei);
-					else st.setEffectId(ei, prevCells_.at(i / 2).at(j));
+					step.setNoteNumber(std::stoi(prevCells_.at(i / 2).at(j)));
+				}
+				break;
+			}
+
+			case 1: {
+				if (i % 2) {
+					step.clearInstrumentNumber();
+				}
+				else {
+					step.setInstrumentNumber(std::stoi(prevCells_.at(i / 2).at(j)));
+				}
+				break;
+			}
+
+			case 2: {
+				if (i % 2) {
+					step.clearVolume();
+				}
+				else {
+					step.setVolume(std::stoi(prevCells_.at(i / 2).at(j)));
+				}
+				break;
+			}
+
+			default: {
+				int effectColumnIndex = columnIndex - 3;
+				int effectNumber = effectColumnIndex / 2;
+				if (effectColumnIndex % 2) {
+					// Effect value column.
+					if (i % 2) {
+						step.clearEffectValue(effectNumber);
+					}
+					else {
+						step.setEffectValue(effectNumber, std::stoi(prevCells_.at(i / 2).at(j)));
+					}
+				}
+				else {
+					// Effect ID column.
+					if (i % 2) {
+						step.clearEffectId(effectNumber);
+					}
+					else {
+						step.setEffectId(effectNumber, prevCells_.at(i / 2).at(j));
+					}
 				}
 				break;
 			}
 			}
 
-			t += (++c / Step::N_COLUMN);
-			c %= Step::N_COLUMN;
+			trackIndex += (++columnIndex / Step::N_COLUMN);
+			columnIndex %= Step::N_COLUMN;
 		}
 
-		++s;
+		++stepIndex;
 	}
+
+	return true;
 }
 
-void ExpandPatternCommand::undo()
+bool ExpandPatternCommand::undo()
 {
-	command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, bTrack_, bCol_, order_, bStep_);
+	try {
+		command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, bTrack_, bCol_, order_, bStep_);
+		return true;
+	}
+	catch (...) {
+		return false;
+	}
 }

--- a/BambooTracker/command/pattern/expand_pattern_command.hpp
+++ b/BambooTracker/command/pattern/expand_pattern_command.hpp
@@ -1,35 +1,15 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <string>
 #include "../abstract_command.hpp"
 #include "module.hpp"
+#include "vector_2d.hpp"
 
 class ExpandPatternCommand final : public AbstractCommand
 {
@@ -37,11 +17,11 @@ public:
 	ExpandPatternCommand(std::weak_ptr<Module> mod, int songNum,
 						 int beginTrack, int beginColumn, int beginOrder, int beginStep,
 						 int endTrack, int endColumn, int endStep);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;
 	int song_, bTrack_, bCol_, order_, bStep_;
-	std::vector<std::vector<std::string>> prevCells_;
+	Vector2d<std::string> prevCells_;
 };

--- a/BambooTracker/command/pattern/insert_step_command.cpp
+++ b/BambooTracker/command/pattern/insert_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "insert_step_command.hpp"
@@ -37,12 +17,14 @@ InsertStepCommand::InsertStepCommand(
 {
 }
 
-void InsertStepCommand::redo()
+bool InsertStepCommand::redo()
 {
 	command_utils::getPattern(mod_, song_, track_, order_).insertStep(step_);
+	return true;
 }
 
-void InsertStepCommand::undo()
+bool InsertStepCommand::undo()
 {
 	command_utils::getPattern(mod_, song_, track_, order_).deletePreviousStep(step_ + 1);
+	return true;
 }

--- a/BambooTracker/command/pattern/insert_step_command.hpp
+++ b/BambooTracker/command/pattern/insert_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -33,8 +13,8 @@ class InsertStepCommand final : public AbstractCommand
 {
 public:
 	InsertStepCommand(std::weak_ptr<Module> mod, int songNum, int trackNum, int orderNum, int stepNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/pattern/interpolate_pattern_command.hpp
+++ b/BambooTracker/command/pattern/interpolate_pattern_command.hpp
@@ -1,35 +1,15 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <string>
 #include "../abstract_command.hpp"
 #include "module.hpp"
+#include "vector_2d.hpp"
 
 class InterpolatePatternCommand final : public AbstractCommand
 {
@@ -37,12 +17,12 @@ public:
 	InterpolatePatternCommand(std::weak_ptr<Module> mod, int songNum,
 							  int beginTrack, int beginColumn, int beginOrder, int beginStep,
 							  int endTrack, int endColumn, int endStep);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;
 	int song_, bTrack_, bCol_, order_, bStep_;
 	int eStep_;
-	std::vector<std::vector<std::string>> prevCells_;
+	Vector2d<std::string> prevCells_;
 };

--- a/BambooTracker/command/pattern/paste_copied_data_to_pattern_command.cpp
+++ b/BambooTracker/command/pattern/paste_copied_data_to_pattern_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "paste_copied_data_to_pattern_command.hpp"
@@ -28,7 +8,7 @@
 
 PasteCopiedDataToPatternCommand::PasteCopiedDataToPatternCommand(
 		std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginColmn,
-		int beginOrder, int beginStep, const std::vector<std::vector<std::string>>& cells)
+		int beginOrder, int beginStep, const Vector2d<std::string>& cells)
 	: AbstractCommand(CommandId::PasteCopiedDataToPattern),
 	  mod_(mod),
 	  song_(songNum),
@@ -39,16 +19,28 @@ PasteCopiedDataToPatternCommand::PasteCopiedDataToPatternCommand(
 	  cells_(cells)
 {
 	auto& song = mod.lock()->getSong(songNum);
-	prevCells_ = command_utils::getPreviousCells(song, cells.front().size(), cells.size(),
+	prevCells_ = command_utils::getPreviousCells(song, cells.columnSize(), cells.rowSize(),
 												 beginTrack, beginColmn, beginOrder, beginStep);
 }
 
-void PasteCopiedDataToPatternCommand::redo()
+bool PasteCopiedDataToPatternCommand::redo()
 {
-	command_utils::restorePattern(mod_.lock()->getSong(song_), cells_, track_, col_, order_, step_);
+	try {
+		command_utils::restorePattern(mod_.lock()->getSong(song_), cells_, track_, col_, order_, step_);
+		return true;
+	}
+	catch (...) {
+		return false;
+	}
 }
 
-void PasteCopiedDataToPatternCommand::undo()
+bool PasteCopiedDataToPatternCommand::undo()
 {
-	command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, track_, col_, order_, step_);
+	try {
+		command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, track_, col_, order_, step_);
+		return true;
+	}
+	catch (...) {
+		return false;
+	}
 }

--- a/BambooTracker/command/pattern/paste_copied_data_to_pattern_command.hpp
+++ b/BambooTracker/command/pattern/paste_copied_data_to_pattern_command.hpp
@@ -1,47 +1,27 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <string>
 #include "../abstract_command.hpp"
 #include "module.hpp"
+#include "vector_2d.hpp"
 
 class PasteCopiedDataToPatternCommand final : public AbstractCommand
 {
 public:
 	PasteCopiedDataToPatternCommand(
 			std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginColmn,
-			int beginOrder, int beginStep, const std::vector<std::vector<std::string>>& cells);
-	void redo() override;
-	void undo() override;
+			int beginOrder, int beginStep, const Vector2d<std::string>& cells);
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;
 	int song_, track_, col_, order_, step_;
-	std::vector<std::vector<std::string>> cells_, prevCells_;
+	Vector2d<std::string> cells_, prevCells_;
 };

--- a/BambooTracker/command/pattern/paste_insert_copied_data_to_pattern_command.cpp
+++ b/BambooTracker/command/pattern/paste_insert_copied_data_to_pattern_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2020 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "paste_insert_copied_data_to_pattern_command.hpp"
@@ -29,32 +9,47 @@
 #include "pattern_command_utils.hpp"
 
 PasteInsertCopiedDataToPatternCommand::PasteInsertCopiedDataToPatternCommand(
-		std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginColumn,
-		int beginOrder, int beginStep, const std::vector<std::vector<std::string>>& cells)
+	std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginColumn,
+		int beginOrder, int beginStep, const Vector2d<std::string>& cells)
 	: AbstractCommand(CommandId::PasteInsertCopiedDataToPattern),
 	  mod_(mod),
 	  song_(songNum),
 	  track_(beginTrack),
 	  col_(beginColumn),
 	  order_(beginOrder),
-	  step_(beginStep),
-	  cells_(cells)
+	  step_(beginStep)
 {
 	auto& song = mod.lock()->getSong(songNum);
 	size_t newStepSize = song.getTrack(track_).getPatternFromOrderNumber(order_).getSize() - step_;
-	prevCells_ = command_utils::getPreviousCells(song, cells.front().size(), newStepSize,
+	prevCells_ = command_utils::getPreviousCells(song, cells.columnSize(), newStepSize,
 												 beginTrack, beginColumn, beginOrder, beginStep);
-	if (cells.size() < newStepSize) {
-		std::copy(prevCells_.begin(), prevCells_.end() - cells.size(), std::back_inserter(cells_));
+
+	Vector2d<std::string> newCells(newStepSize, cells.columnSize());
+	std::size_t shiftedRowIndex = std::min(cells.rowSize(), newStepSize);
+	std::copy_n(cells.begin(), shiftedRowIndex, newCells.begin());
+	std::copy_n(prevCells_.begin(), newStepSize - shiftedRowIndex, newCells.begin() + shiftedRowIndex);
+	cells_ = newCells;
+}
+
+bool PasteInsertCopiedDataToPatternCommand::redo()
+{
+	try {
+		command_utils::restorePattern(mod_.lock()->getSong(song_), cells_, track_, col_, order_, step_);
+		return true;
 	}
+	catch (...) {
+		return false;
+	}
+
 }
 
-void PasteInsertCopiedDataToPatternCommand::redo()
+bool PasteInsertCopiedDataToPatternCommand::undo()
 {
-	command_utils::restorePattern(mod_.lock()->getSong(song_), cells_, track_, col_, order_, step_);
-}
-
-void PasteInsertCopiedDataToPatternCommand::undo()
-{
-	command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, track_, col_, order_, step_);
+	try {
+		command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, track_, col_, order_, step_);
+		return true;
+	}
+	catch (...) {
+		return false;
+	}
 }

--- a/BambooTracker/command/pattern/paste_insert_copied_data_to_pattern_command.hpp
+++ b/BambooTracker/command/pattern/paste_insert_copied_data_to_pattern_command.hpp
@@ -1,47 +1,27 @@
 /*
- * Copyright (C) 2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2020 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <string>
 #include "../abstract_command.hpp"
 #include "module.hpp"
+#include "vector_2d.hpp"
 
 class PasteInsertCopiedDataToPatternCommand final : public AbstractCommand
 {
 public:
 	PasteInsertCopiedDataToPatternCommand(
 			std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginColumn,
-			int beginOrder, int beginStep, const std::vector<std::vector<std::string>>& cells);
-	void redo() override;
-	void undo() override;
+			int beginOrder, int beginStep, const Vector2d<std::string>& cells);
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;
 	int song_, track_, col_, order_, step_;
-	std::vector<std::vector<std::string>> cells_, prevCells_;
+	Vector2d<std::string> cells_, prevCells_;
 };

--- a/BambooTracker/command/pattern/paste_mix_copied_data_to_pattern_command.cpp
+++ b/BambooTracker/command/pattern/paste_mix_copied_data_to_pattern_command.cpp
@@ -1,34 +1,14 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "paste_mix_copied_data_to_pattern_command.hpp"
 #include "pattern_command_utils.hpp"
 
 PasteMixCopiedDataToPatternCommand::PasteMixCopiedDataToPatternCommand(
-		std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginColumn,
-		int beginOrder, int beginStep, const std::vector<std::vector<std::string>>& cells)
+	std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginColumn,
+		int beginOrder, int beginStep, const Vector2d<std::string>& cells)
 	: AbstractCommand(CommandId::PasteMixCopiedDataToPattern),
 	  mod_(mod),
 	  song_(songNum),
@@ -39,69 +19,100 @@ PasteMixCopiedDataToPatternCommand::PasteMixCopiedDataToPatternCommand(
 	  cells_(cells)
 {
 	auto& song = mod.lock()->getSong(songNum);
-	prevCells_ = command_utils::getPreviousCells(song, cells.front().size(), cells.size(),
+	prevCells_ = command_utils::getPreviousCells(song, cells.columnSize(), cells.rowSize(),
 												 beginTrack, beginColumn, beginOrder, beginStep);
 }
 
-void PasteMixCopiedDataToPatternCommand::redo()
+bool PasteMixCopiedDataToPatternCommand::redo()
 {
-	auto& sng = mod_.lock()->getSong(song_);
+	try {
+		auto& song = mod_.lock()->getSong(song_);
 
-	int s = step_;
-	int o = order_;
-	for (const auto& row : cells_) {
-		int t = track_;
-		int c = col_;
-		for (const std::string& cell : row) {
-			if (static_cast<size_t>(s) >= sng.getTrack(t).getPatternFromOrderNumber(o).getSize()) {
-				if (static_cast<size_t>(++o) < sng.getTrack(t).getOrderSize()) { s = 0; }
-				else { return; }
-			}
-			Step& step = command_utils::getStep(sng, t, o, s);
-			switch (c) {
-			case 0:
-			{
-				int n = std::stoi(cell);
-				if (!Step::testEmptyNote(n) && step.isEmptyNote()) step.setNoteNumber(n);
-				break;
-			}
-			case 1:
-			{
-				int n = std::stoi(cell);
-				if (!Step::testEmptyInstrument(n) && !step.hasInstrument()) step.setInstrumentNumber(n);
-				break;
-			}
-			case 2:
-			{
-				int vol = std::stoi(cell);
-				if (!Step::testEmptyVolume(vol) && !step.hasVolume()) step.setVolume(vol);
-				break;
-			}
-			default:
-			{
-				int ec = c - 3;
-				int ei = ec / 2;
-				if (ec % 2) {	// Value
-					int val = std::stoi(cell);
-					if (!Step::testEmptyEffectValue(val) && !step.hasEffectValue(ei)) step.setEffectValue(ei, val);
+		int stepIndex = step_;
+		int orderIndex = order_;
+
+		for (const auto& row : cells_) {
+			int trackIndex = track_;
+			int columnIndex = col_;
+
+			for (const std::string& cell : row) {
+				if (static_cast<std::size_t>(stepIndex) >= song.getTrack(trackIndex).getPatternFromOrderNumber(orderIndex).getSize()) {
+					if (static_cast<std::size_t>(++orderIndex) < song.getTrack(trackIndex).getOrderSize()) {
+						stepIndex = 0;
+					}
+					else {
+						return true;
+					}
 				}
-				else {	// ID
-					if (!Step::testEmptyEffectId(cell) && !step.hasEffectId(ei)) step.setEffectId(ei, cell);
+
+				Step& step = command_utils::getStep(song, trackIndex, orderIndex, stepIndex);
+				switch (columnIndex) {
+				case 0: {
+					int n = std::stoi(cell);
+					if (!Step::testEmptyNote(n) && step.isEmptyNote()) {
+						step.setNoteNumber(n);
+					}
+					break;
 				}
-				break;
-			}
+
+				case 1: {
+					int n = std::stoi(cell);
+					if (!Step::testEmptyInstrument(n) && !step.hasInstrument()) {
+						step.setInstrumentNumber(n);
+					}
+					break;
+				}
+
+				case 2: {
+					int volume = std::stoi(cell);
+					if (!Step::testEmptyVolume(volume) && !step.hasVolume()) {
+						step.setVolume(volume);
+					}
+					break;
+				}
+
+				default: {
+					int effectColumnIndex = columnIndex - 3;
+					int effectNumber = effectColumnIndex / 2;
+					if (effectColumnIndex % 2) {
+						// Effect value column.
+						int value = std::stoi(cell);
+						if (!Step::testEmptyEffectValue(value) && !step.hasEffectValue(effectNumber)) {
+							step.setEffectValue(effectNumber, value);
+						}
+					}
+					else {
+						// Effect ID column.
+						if (!Step::testEmptyEffectId(cell) && !step.hasEffectId(effectNumber)) {
+							step.setEffectId(effectNumber, cell);
+						}
+					}
+					break;
+				}
+				}
+
+				++columnIndex;
+				trackIndex += (columnIndex / Step::N_COLUMN);
+				columnIndex %= Step::N_COLUMN;
 			}
 
-			++c;
-			t += (c / Step::N_COLUMN);
-			c %= Step::N_COLUMN;
+			++stepIndex;
 		}
 
-		++s;
+		return true;
+	}
+	catch (...) {
+		return false;
 	}
 }
 
-void PasteMixCopiedDataToPatternCommand::undo()
+bool PasteMixCopiedDataToPatternCommand::undo()
 {
-	command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, track_, col_, order_, step_);
+	try {
+		command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, track_, col_, order_, step_);
+		return true;
+	}
+	catch (...) {
+		return false;
+	}
 }

--- a/BambooTracker/command/pattern/paste_mix_copied_data_to_pattern_command.hpp
+++ b/BambooTracker/command/pattern/paste_mix_copied_data_to_pattern_command.hpp
@@ -1,47 +1,27 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <string>
 #include "../abstract_command.hpp"
 #include "module.hpp"
+#include "vector_2d.hpp"
 
 class PasteMixCopiedDataToPatternCommand final : public AbstractCommand
 {
 public:
 	PasteMixCopiedDataToPatternCommand(
 			std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginColumn,
-			int beginOrder, int beginStep, const std::vector<std::vector<std::string>>& cells);
-	void redo() override;
-	void undo() override;
+			int beginOrder, int beginStep, const Vector2d<std::string>& cells);
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;
 	int song_, track_, col_, order_, step_;
-	std::vector<std::vector<std::string>> cells_, prevCells_;
+	Vector2d<std::string> cells_, prevCells_;
 };

--- a/BambooTracker/command/pattern/paste_overwrite_copied_data_to_pattern_command.cpp
+++ b/BambooTracker/command/pattern/paste_overwrite_copied_data_to_pattern_command.cpp
@@ -1,34 +1,14 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "paste_overwrite_copied_data_to_pattern_command.hpp"
 #include "pattern_command_utils.hpp"
 
 PasteOverwriteCopiedDataToPatternCommand::PasteOverwriteCopiedDataToPatternCommand(
-		std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginColumn,
-		int beginOrder, int beginStep, const std::vector<std::vector<std::string>>& cells)
+	std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginColumn,
+		int beginOrder, int beginStep, const Vector2d<std::string>& cells)
 	: AbstractCommand(CommandId::PasteOverwriteCopiedDataToPattern),
 	  mod_(mod),
 	  song_(songNum),
@@ -39,68 +19,94 @@ PasteOverwriteCopiedDataToPatternCommand::PasteOverwriteCopiedDataToPatternComma
 	  cells_(cells)
 {
 	auto& song = mod.lock()->getSong(songNum);
-	prevCells_ = command_utils::getPreviousCells(song, cells.front().size(), cells.size(),
+	prevCells_ = command_utils::getPreviousCells(song, cells.columnSize(), cells.rowSize(),
 												 beginTrack, beginColumn, beginOrder, beginStep);
 }
 
-void PasteOverwriteCopiedDataToPatternCommand::redo()
+bool PasteOverwriteCopiedDataToPatternCommand::redo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 
-	int s = step_;
-	int o = order_;
+	int stepIndex = step_;
+	int orderIndex = order_;
+
 	for (const auto& row : cells_) {
-		int t = track_;
-		int c = col_;
+		int trackIndex = track_;
+		int columnIndex = col_;
+
 		for (const std::string& cell : row) {
-			if (static_cast<size_t>(s) >= sng.getTrack(t).getPatternFromOrderNumber(o).getSize()) {
-				if (static_cast<size_t>(++o) < sng.getTrack(t).getOrderSize()) { s = 0; }
-				else { return; }
-			}
-			Step& st = command_utils::getStep(sng, t, o, s);
-			switch (c) {
-			case 0:
-			{
-				int n = std::stoi(cell);
-				if (!Step::testEmptyNote(n)) st.setNoteNumber(n);
-				break;
-			}
-			case 1:
-			{
-				int n = std::stoi(cell);
-				if (!Step::testEmptyInstrument(n)) st.setInstrumentNumber(n);
-				break;
-			}
-			case 2:
-			{
-				int vol = std::stoi(cell);
-				if (!Step::testEmptyVolume(vol)) st.setVolume(vol);
-				break;
-			}
-			default:
-			{
-				int ec = c - 3;
-				int ei = ec / 2;
-				if (ec % 2) {
-					int val = std::stoi(cell);
-					if (!Step::testEmptyEffectValue(val)) st.setEffectValue(ei, val);
+			if (static_cast<std::size_t>(stepIndex) >= sng.getTrack(trackIndex).getPatternFromOrderNumber(orderIndex).getSize()) {
+				if (static_cast<std::size_t>(++orderIndex) < sng.getTrack(trackIndex).getOrderSize()) {
+					stepIndex = 0;
 				}
 				else {
-					if (!Step::testEmptyEffectId(cell)) st.setEffectId(ei, cell);
+					return true;
+				}
+			}
+
+			Step& step = command_utils::getStep(sng, trackIndex, orderIndex, stepIndex);
+			switch (columnIndex) {
+			case 0: {
+				int n = std::stoi(cell);
+				if (!Step::testEmptyNote(n)) {
+					step.setNoteNumber(n);
+				}
+				break;
+			}
+
+			case 1: {
+				int n = std::stoi(cell);
+				if (!Step::testEmptyInstrument(n)) {
+					step.setInstrumentNumber(n);
+				}
+				break;
+			}
+
+			case 2: {
+				int volume = std::stoi(cell);
+				if (!Step::testEmptyVolume(volume)) {
+					step.setVolume(volume);
+				}
+				break;
+			}
+
+			default: {
+				int effectColumnIndex = columnIndex - 3;
+				int effectNumber = effectColumnIndex / 2;
+				if (effectColumnIndex % 2) {
+					// Effect value column.
+					int value = std::stoi(cell);
+					if (!Step::testEmptyEffectValue(value)) {
+						step.setEffectValue(effectNumber, value);
+					}
+				}
+				else {
+					// Effect ID column.
+					if (!Step::testEmptyEffectId(cell)) {
+						step.setEffectId(effectNumber, cell);
+					}
 				}
 				break;
 			}
 			}
 
-			t += (++c / Step::N_COLUMN);
-			c %= Step::N_COLUMN;
+			trackIndex += (++columnIndex / Step::N_COLUMN);
+			columnIndex %= Step::N_COLUMN;
 		}
 
-		++s;
+		++stepIndex;
 	}
+
+	return true;
 }
 
-void PasteOverwriteCopiedDataToPatternCommand::undo()
+bool PasteOverwriteCopiedDataToPatternCommand::undo()
 {
-	command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, track_, col_, order_, step_);
+	try {
+		command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, track_, col_, order_, step_);
+		return true;
+	}
+	catch (...) {
+		return false;
+	}
 }

--- a/BambooTracker/command/pattern/paste_overwrite_copied_data_to_pattern_command.hpp
+++ b/BambooTracker/command/pattern/paste_overwrite_copied_data_to_pattern_command.hpp
@@ -1,47 +1,27 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <string>
 #include "../abstract_command.hpp"
 #include "module.hpp"
+#include "vector_2d.hpp"
 
 class PasteOverwriteCopiedDataToPatternCommand final : public AbstractCommand
 {
 public:
 	PasteOverwriteCopiedDataToPatternCommand(
 			std::weak_ptr<Module> mod, int songNum, int beginTrack, int beginColumn,
-			int beginOrder, int beginStep, const std::vector<std::vector<std::string>>& cells);
-	void redo() override;
-	void undo() override;
+			int beginOrder, int beginStep, const Vector2d<std::string>& cells);
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;
 	int song_, track_, col_, order_, step_;
-	std::vector<std::vector<std::string>> cells_, prevCells_;
+	Vector2d<std::string> cells_, prevCells_;
 };

--- a/BambooTracker/command/pattern/pattern_command_utils.hpp
+++ b/BambooTracker/command/pattern/pattern_command_utils.hpp
@@ -1,34 +1,14 @@
 /*
- * Copyright (C) 2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2020 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
 
-#include <vector>
 #include <string>
 #include <memory>
 #include "module.hpp"
+#include "vector_2d.hpp"
 
 namespace command_utils
 {
@@ -55,9 +35,12 @@ inline Pattern& getPattern(Song& song, int track, int order)
 
 size_t calculateColumnSize(int beginTrack, int beginColumn, int endTrack, int endColumn);
 
-std::vector<std::vector<std::string>> getPreviousCells(Song& song, size_t w, size_t h, int beginTrack,
-													   int beginColumn, int beginOrder, int beginStep);
+Vector2d<std::string> getPreviousCells(Song& song, std::size_t w, std::size_t h, int beginTrack,
+                                       int beginColumn, int beginOrder, int beginStep);
 
-void restorePattern(Song& song, const std::vector<std::vector<std::string>>& cells, int beginTrack,
+/**
+ * @throw @c std::invalid_argument or @c std::out_of_range if @c cells contain invalid data.
+ */
+void restorePattern(Song& song, const Vector2d<std::string>& cells, int beginTrack,
 					int beginColumn, int beginOrder, int beginStep);
 }

--- a/BambooTracker/command/pattern/replace_instrument_in_pattern_command.cpp
+++ b/BambooTracker/command/pattern/replace_instrument_in_pattern_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "replace_instrument_in_pattern_command.hpp"
@@ -49,7 +29,7 @@ ReplaceInstrumentInPatternCommand::ReplaceInstrumentInPatternCommand(
 	}
 }
 
-void ReplaceInstrumentInPatternCommand::redo()
+bool ReplaceInstrumentInPatternCommand::redo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 
@@ -59,9 +39,10 @@ void ReplaceInstrumentInPatternCommand::redo()
 			if (st.hasInstrument()) st.setInstrumentNumber(inst_);
 		}
 	}
+	return true;
 }
 
-void ReplaceInstrumentInPatternCommand::undo()
+bool ReplaceInstrumentInPatternCommand::undo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 
@@ -72,4 +53,5 @@ void ReplaceInstrumentInPatternCommand::undo()
 			if (st.hasInstrument()) st.setInstrumentNumber(prevInsts_.at(i++));
 		}
 	}
+	return true;
 }

--- a/BambooTracker/command/pattern/replace_instrument_in_pattern_command.hpp
+++ b/BambooTracker/command/pattern/replace_instrument_in_pattern_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -36,8 +16,8 @@ public:
 	ReplaceInstrumentInPatternCommand(std::weak_ptr<Module> mod, int songNum,
 									  int beginTrack, int beginOrder, int beginStep,
 									  int endTrack, int endStep, int newInst);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/pattern/reverse_pattern_command.cpp
+++ b/BambooTracker/command/pattern/reverse_pattern_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "reverse_pattern_command.hpp"
@@ -38,45 +18,70 @@ ReversePatternCommand::ReversePatternCommand(
 	  bStep_(beginStep)
 {
 	auto& song = mod.lock()->getSong(songNum);
-	size_t h = static_cast<size_t>(endStep - beginStep + 1);
-	size_t w = command_utils::calculateColumnSize(beginTrack, beginColumn, endTrack, endColumn);
+	std::size_t h = static_cast<size_t>(endStep - beginStep + 1);
+	std::size_t w = command_utils::calculateColumnSize(beginTrack, beginColumn, endTrack, endColumn);
 	prevCells_ = command_utils::getPreviousCells(song, w, h, beginTrack, beginColumn, beginOrder, beginStep);
 }
 
-void ReversePatternCommand::redo()
+bool ReversePatternCommand::redo()
 {
-	auto& sng = mod_.lock()->getSong(song_);
+	auto& song = mod_.lock()->getSong(song_);
 
-	size_t l = prevCells_.size() - 1;
-	int s = bStep_;
-	for (size_t i = 0; i < prevCells_.size(); ++i) {
-		int t = bTrack_;
-		int c = bCol_;
-		for (size_t j = 0; j < prevCells_.at(i).size(); ++j) {
-			Step& st = command_utils::getStep(sng, t, order_, s);
-			switch (c) {
-			case 0:		st.setNoteNumber(std::stoi(prevCells_.at(l - i).at(j)));		break;
-			case 1:		st.setInstrumentNumber(std::stoi(prevCells_.at(l - i).at(j)));	break;
-			case 2:		st.setVolume(std::stoi(prevCells_.at(l - i).at(j)));			break;
-			default:
-			{
-				int ec = c - 3;
-				int ei = ec / 2;
-				if (ec % 2) st.setEffectValue(ei, std::stoi(prevCells_.at(l - i).at(j)));
-				else st.setEffectId(ei, prevCells_.at(l - i).at(j));
+	std::size_t lastRowIndex = prevCells_.rowSize() - 1;
+	int stepIndex = bStep_;
+
+	for (std::size_t i = 0; i < prevCells_.rowSize(); ++i) {
+		int trackIndex = bTrack_;
+		int columnIndex = bCol_;
+
+		for (std::size_t j = 0; j < prevCells_.columnSize(); ++j) {
+			Step& step = command_utils::getStep(song, trackIndex, order_, stepIndex);
+
+			switch (columnIndex) {
+			case 0:
+				step.setNoteNumber(std::stoi(prevCells_.at(lastRowIndex - i).at(j)));
+				break;
+
+			case 1:
+				step.setInstrumentNumber(std::stoi(prevCells_.at(lastRowIndex - i).at(j)));
+				break;
+
+			case 2:
+				step.setVolume(std::stoi(prevCells_.at(lastRowIndex - i).at(j)));
+				break;
+
+			default: {
+				int effectColumnIndex = columnIndex - 3;
+				int effectNumber = effectColumnIndex / 2;
+				if (effectColumnIndex % 2) {
+					// Effect value column.
+					step.setEffectValue(effectNumber, std::stoi(prevCells_.at(lastRowIndex - i).at(j)));
+				}
+				else {
+					// Effect ID column.
+					step.setEffectId(effectNumber, prevCells_.at(lastRowIndex - i).at(j));
+				}
 				break;
 			}
 			}
 
-			t += (++c / Step::N_COLUMN);
-			c %= Step::N_COLUMN;
+			trackIndex += (++columnIndex / Step::N_COLUMN);
+			columnIndex %= Step::N_COLUMN;
 		}
 
-		++s;
+		++stepIndex;
 	}
+
+	return true;
 }
 
-void ReversePatternCommand::undo()
+bool ReversePatternCommand::undo()
 {
-	command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, bTrack_, bCol_, order_, bStep_);
+	try {
+		command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, bTrack_, bCol_, order_, bStep_);
+		return true;
+	}
+	catch (...) {
+		return false;
+	}
 }

--- a/BambooTracker/command/pattern/reverse_pattern_command.hpp
+++ b/BambooTracker/command/pattern/reverse_pattern_command.hpp
@@ -1,35 +1,15 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <string>
 #include "../abstract_command.hpp"
 #include "module.hpp"
+#include "vector_2d.hpp"
 
 class ReversePatternCommand final : public AbstractCommand
 {
@@ -37,11 +17,11 @@ public:
 	ReversePatternCommand(std::weak_ptr<Module> mod, int songNum,
 						  int beginTrack, int beginColumn, int beginOrder, int beginStep,
 						  int endTrack, int endColumn, int endStep);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;
 	int song_, bTrack_, bCol_, order_, bStep_;
-	std::vector<std::vector<std::string>> prevCells_;
+	Vector2d<std::string> prevCells_;
 };

--- a/BambooTracker/command/pattern/set_echo_buffer_access_command.cpp
+++ b/BambooTracker/command/pattern/set_echo_buffer_access_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "set_echo_buffer_access_command.hpp"
@@ -39,12 +19,14 @@ SetEchoBufferAccessCommand::SetEchoBufferAccessCommand(
 	prevNote_ = command_utils::getStep(mod, songNum, trackNum, orderNum, stepNum).getNoteNumber();
 }
 
-void SetEchoBufferAccessCommand::redo()
+bool SetEchoBufferAccessCommand::redo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).setEchoBuffer(buf_);
+	return true;
 }
 
-void SetEchoBufferAccessCommand::undo()
+bool SetEchoBufferAccessCommand::undo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).setNoteNumber(prevNote_);
+	return true;
 }

--- a/BambooTracker/command/pattern/set_echo_buffer_access_command.hpp
+++ b/BambooTracker/command/pattern/set_echo_buffer_access_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -35,8 +15,8 @@ class SetEchoBufferAccessCommand final : public AbstractCommand
 public:
 	SetEchoBufferAccessCommand(std::weak_ptr<Module> mod, int songNum, int trackNum,
 							   int orderNum, int stepNum, int bufNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/pattern/set_effect_id_to_step_command.cpp
+++ b/BambooTracker/command/pattern/set_effect_id_to_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "set_effect_id_to_step_command.hpp"
@@ -44,15 +24,16 @@ SetEffectIDToStepCommand::SetEffectIDToStepCommand(
 	filledValue00_ = fillValue00 && !step.hasEffectValue(n);
 }
 
-void SetEffectIDToStepCommand::redo()
+bool SetEffectIDToStepCommand::redo()
 {
 	std::string str = isSecondEntry_ ? effID_ : ("0" + effID_);
 	Step& step = command_utils::getStep(mod_, song_, track_, order_, step_);
 	step.setEffectId(n_, str);
 	if (filledValue00_) step.setEffectValue(n_, 0);
+	return true;
 }
 
-void SetEffectIDToStepCommand::undo()
+bool SetEffectIDToStepCommand::undo()
 {
 	Step& step = command_utils::getStep(mod_, song_, track_, order_, step_);
 	step.setEffectId(n_, prevEffID_);
@@ -62,6 +43,7 @@ void SetEffectIDToStepCommand::undo()
 		effID_ = "0" + effID_;
 		isSecondEntry_ = true;
 	}
+	return true;
 }
 
 bool SetEffectIDToStepCommand::mergeWith(const AbstractCommand* other)

--- a/BambooTracker/command/pattern/set_effect_id_to_step_command.hpp
+++ b/BambooTracker/command/pattern/set_effect_id_to_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -36,8 +16,8 @@ public:
 	SetEffectIDToStepCommand(
 			std::weak_ptr<Module> mod, int songNum, int trackNum, int orderNum, int stepNum,
 			int n, std::string id, bool fillValue00, bool secondEntry);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 	bool mergeWith(const AbstractCommand* other) override;
 
 private:

--- a/BambooTracker/command/pattern/set_effect_value_to_step_command.cpp
+++ b/BambooTracker/command/pattern/set_effect_value_to_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "set_effect_value_to_step_command.hpp"
@@ -44,7 +24,7 @@ SetEffectValueToStepCommand::SetEffectValueToStepCommand(
 	prevVal_ = command_utils::getStep(mod, songNum, trackNum, orderNum, stepNum).getEffectValue(n);
 }
 
-void SetEffectValueToStepCommand::redo()
+bool SetEffectValueToStepCommand::redo()
 {
 	int value;
 	switch (ctrl_) {
@@ -60,12 +40,14 @@ void SetEffectValueToStepCommand::redo()
 		break;
 	}
 	command_utils::getStep(mod_, song_, track_, order_, step_).setEffectValue(n_, value);
+	return true;
 }
 
-void SetEffectValueToStepCommand::undo()
+bool SetEffectValueToStepCommand::undo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).setEffectValue(n_, prevVal_);
 	isSecondEntry_ = true;	// Forced complete
+	return true;
 }
 
 bool SetEffectValueToStepCommand::mergeWith(const AbstractCommand* other)

--- a/BambooTracker/command/pattern/set_effect_value_to_step_command.hpp
+++ b/BambooTracker/command/pattern/set_effect_value_to_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -40,8 +20,8 @@ public:
 	SetEffectValueToStepCommand(std::weak_ptr<Module> mod, int songNum, int trackNum,
 								int orderNum, int stepNum, int n, int value,
 								EffectDisplayControl ctrl, bool secondEntry);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 	bool mergeWith(const AbstractCommand* other) override;
 
 private:

--- a/BambooTracker/command/pattern/set_instrument_to_step_command.cpp
+++ b/BambooTracker/command/pattern/set_instrument_to_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "set_instrument_to_step_command.hpp"
@@ -41,15 +21,17 @@ SetInstrumentToStepCommand::SetInstrumentToStepCommand(
 {
 }
 
-void SetInstrumentToStepCommand::redo()
+bool SetInstrumentToStepCommand::redo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).setInstrumentNumber(inst_);
+	return true;
 }
 
-void SetInstrumentToStepCommand::undo()
+bool SetInstrumentToStepCommand::undo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).setInstrumentNumber(prevInst_);
 	isSecondEntry_ = true;	// Forced complete
+	return true;
 }
 
 bool SetInstrumentToStepCommand::mergeWith(const AbstractCommand* other)

--- a/BambooTracker/command/pattern/set_instrument_to_step_command.hpp
+++ b/BambooTracker/command/pattern/set_instrument_to_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -34,8 +14,8 @@ class SetInstrumentToStepCommand final : public AbstractCommand
 public:
 	SetInstrumentToStepCommand(std::weak_ptr<Module> mod, int songNum, int trackNum,
 							   int orderNum, int stepNum, int instNum, bool secondEntry);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 	bool mergeWith(const AbstractCommand* other) override;
 
 private:

--- a/BambooTracker/command/pattern/set_key_cut_to_step_command.cpp
+++ b/BambooTracker/command/pattern/set_key_cut_to_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2022 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2022 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "set_key_cut_to_step_command.hpp"
@@ -44,7 +24,7 @@ SetKeyCutToStepCommand::SetKeyCutToStepCommand(
 	}
 }
 
-void SetKeyCutToStepCommand::redo()
+bool SetKeyCutToStepCommand::redo()
 {
 	Step& st = command_utils::getStep(mod_, song_, track_, order_, step_);
 	st.setKeyCut();
@@ -53,9 +33,10 @@ void SetKeyCutToStepCommand::redo()
 	for (int i = 0; i < Step::N_EFFECT; ++i) {
 		st.clearEffect(i);
 	}
+	return true;
 }
 
-void SetKeyCutToStepCommand::undo()
+bool SetKeyCutToStepCommand::undo()
 {
 	Step& st = command_utils::getStep(mod_, song_, track_, order_, step_);
 	st.setNoteNumber(prevNote_);
@@ -64,4 +45,5 @@ void SetKeyCutToStepCommand::undo()
 	for (int i = 0; i < Step::N_EFFECT; ++i) {
 		st.setEffect(i, prevEff_[i]);
 	}
+	return true;
 }

--- a/BambooTracker/command/pattern/set_key_cut_to_step_command.hpp
+++ b/BambooTracker/command/pattern/set_key_cut_to_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2022 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2022 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -35,8 +15,8 @@ class SetKeyCutToStepCommand final : public AbstractCommand
 public:
 	SetKeyCutToStepCommand(std::weak_ptr<Module> mod, int songNum, int trackNum,
 						   int orderNum, int stepNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/pattern/set_key_off_to_step_command.cpp
+++ b/BambooTracker/command/pattern/set_key_off_to_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "set_key_off_to_step_command.hpp"
@@ -44,7 +24,7 @@ SetKeyOffToStepCommand::SetKeyOffToStepCommand(
 	}
 }
 
-void SetKeyOffToStepCommand::redo()
+bool SetKeyOffToStepCommand::redo()
 {
 	Step& st = command_utils::getStep(mod_, song_, track_, order_, step_);
 	st.setKeyOff();
@@ -53,9 +33,10 @@ void SetKeyOffToStepCommand::redo()
 	for (int i = 0; i < Step::N_EFFECT; ++i) {
 		st.clearEffect(i);
 	}
+	return true;
 }
 
-void SetKeyOffToStepCommand::undo()
+bool SetKeyOffToStepCommand::undo()
 {
 	Step& st = command_utils::getStep(mod_, song_, track_, order_, step_);
 	st.setNoteNumber(prevNote_);
@@ -64,4 +45,5 @@ void SetKeyOffToStepCommand::undo()
 	for (int i = 0; i < Step::N_EFFECT; ++i) {
 		st.setEffect(i, prevEff_[i]);
 	}
+	return true;
 }

--- a/BambooTracker/command/pattern/set_key_off_to_step_command.hpp
+++ b/BambooTracker/command/pattern/set_key_off_to_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -35,8 +15,8 @@ class SetKeyOffToStepCommand final : public AbstractCommand
 public:
 	SetKeyOffToStepCommand(std::weak_ptr<Module> mod, int songNum, int trackNum,
 						   int orderNum, int stepNum);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/pattern/set_key_on_to_step_command.cpp
+++ b/BambooTracker/command/pattern/set_key_on_to_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "set_key_on_to_step_command.hpp"
@@ -49,18 +29,20 @@ SetKeyOnToStepCommand::SetKeyOnToStepCommand(
 	if (!volMask) prevVol_ = st.getVolume();
 }
 
-void SetKeyOnToStepCommand::redo()
+bool SetKeyOnToStepCommand::redo()
 {
 	Step& st = command_utils::getStep(mod_, song_, track_, order_, step_);
 	st.setNoteNumber(note_);
 	if (!instMask_) st.setInstrumentNumber(inst_);
 	if (!volMask_) st.setVolume(isFMReversed_ ? effect_utils::reverseFmVolume(vol_) : vol_);
+	return true;
 }
 
-void SetKeyOnToStepCommand::undo()
+bool SetKeyOnToStepCommand::undo()
 {
 	Step& st = command_utils::getStep(mod_, song_, track_, order_, step_);
 	st.setNoteNumber(prevNote_);
 	if (!instMask_) st.setInstrumentNumber(prevInst_);
 	if (!volMask_) st.setVolume(prevVol_);
+	return true;
 }

--- a/BambooTracker/command/pattern/set_key_on_to_step_command.hpp
+++ b/BambooTracker/command/pattern/set_key_on_to_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -35,8 +15,8 @@ public:
 	SetKeyOnToStepCommand(
 			std::weak_ptr<Module> mod, int songNum, int trackNum, int orderNum, int stepNum,
 			int noteNum, bool instMask, int instNum, bool volMask, int vol, bool isFMReversed);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/command/pattern/set_volume_to_step_command.cpp
+++ b/BambooTracker/command/pattern/set_volume_to_step_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "set_volume_to_step_command.hpp"
@@ -43,16 +23,18 @@ SetVolumeToStepCommand::SetVolumeToStepCommand(
 {
 }
 
-void SetVolumeToStepCommand::redo()
+bool SetVolumeToStepCommand::redo()
 {
 	int volume = isFMReversed_ ? effect_utils::reverseFmVolume(vol_) : vol_;
 	command_utils::getStep(mod_, song_, track_, order_, step_).setVolume(volume);
+	return true;
 }
 
-void SetVolumeToStepCommand::undo()
+bool SetVolumeToStepCommand::undo()
 {
 	command_utils::getStep(mod_, song_, track_, order_, step_).setVolume(prevVol_);
 	isSecondEntry_ = true;	// Forced complete
+	return true;
 }
 
 bool SetVolumeToStepCommand::mergeWith(const AbstractCommand* other)

--- a/BambooTracker/command/pattern/set_volume_to_step_command.hpp
+++ b/BambooTracker/command/pattern/set_volume_to_step_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -34,8 +14,8 @@ class SetVolumeToStepCommand final : public AbstractCommand
 public:
 	SetVolumeToStepCommand(std::weak_ptr<Module> mod, int songNum, int trackNum, int orderNum,
 						   int stepNum, int volume, bool isFMReversed, bool secondEntry);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 	bool mergeWith(const AbstractCommand* other) override;
 
 private:

--- a/BambooTracker/command/pattern/shrink_pattern_command.cpp
+++ b/BambooTracker/command/pattern/shrink_pattern_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "shrink_pattern_command.hpp"
@@ -39,68 +19,109 @@ ShrinkPatternCommand::ShrinkPatternCommand(
 	  eStep_(endStep)
 {
 	auto& song = mod.lock()->getSong(songNum);
-	size_t h = static_cast<size_t>(endStep - beginStep + 1);
-	size_t w = command_utils::calculateColumnSize(beginTrack, beginColumn, endTrack, endColumn);
+	std::size_t h = static_cast<size_t>(endStep - beginStep + 1);
+	std::size_t w = command_utils::calculateColumnSize(beginTrack, beginColumn, endTrack, endColumn);
 	prevCells_ = command_utils::getPreviousCells(song, w, h, beginTrack, beginColumn, beginOrder, beginStep);
 }
 
-void ShrinkPatternCommand::redo()
+bool ShrinkPatternCommand::redo()
 {
-	auto& sng = mod_.lock()->getSong(song_);
+	auto& song = mod_.lock()->getSong(song_);
 
-	int s = bStep_;
-	for (size_t i = 0; i < prevCells_.size(); i += 2) {
-		int t = bTrack_;
-		int c = bCol_;
-		for (size_t j = 0; j < prevCells_.at(i).size(); ++j) {
-			Step& st = command_utils::getStep(sng, t, order_, s);
-			switch (c) {
-			case 0:		st.setNoteNumber(std::stoi(prevCells_.at(i).at(j)));		break;
-			case 1:		st.setInstrumentNumber(std::stoi(prevCells_.at(i).at(j)));	break;
-			case 2:		st.setVolume(std::stoi(prevCells_.at(i).at(j)));			break;
-			default:
-			{
-				int ec = c - 3;
-				int ei = ec / 2;
-				if (ec % 2) st.setEffectValue(ei, std::stoi(prevCells_.at(i).at(j)));
-				else st.setEffectId(ei, prevCells_.at(i).at(j));
+	int stepIndex = bStep_;
+	for (std::size_t i = 0; i < prevCells_.rowSize(); i += 2) {
+		int trackIndex = bTrack_;
+		int columnIndex = bCol_;
+
+		for (std::size_t j = 0; j < prevCells_.columnSize(); ++j) {
+			Step& step = command_utils::getStep(song, trackIndex, order_, stepIndex);
+
+			switch (columnIndex) {
+			case 0:
+				step.setNoteNumber(std::stoi(prevCells_.at(i).at(j)));
+				break;
+
+			case 1:
+				step.setInstrumentNumber(std::stoi(prevCells_.at(i).at(j)));
+				break;
+
+			case 2:
+				step.setVolume(std::stoi(prevCells_.at(i).at(j)));
+				break;
+
+			default: {
+				int effectColumnIndex = columnIndex - 3;
+				int effectNumber = effectColumnIndex / 2;
+				if (effectColumnIndex % 2) {
+					// Effect value column.
+					step.setEffectValue(effectNumber, std::stoi(prevCells_.at(i).at(j)));
+				}
+				else {
+					// Effect ID column.
+					step.setEffectId(effectNumber, prevCells_.at(i).at(j));
+				}
 				break;
 			}
 			}
 
-			t += (++c / Step::N_COLUMN);
-			c %= Step::N_COLUMN;
+			trackIndex += (++columnIndex / Step::N_COLUMN);
+			columnIndex %= Step::N_COLUMN;
 		}
 
-		++s;
+		++stepIndex;
 	}
 
-	for (; s <= eStep_; ++s) {
-		int t = bTrack_;
-		int c = bCol_;
-		for (size_t j = 0; j < prevCells_.at(0).size(); ++j) {
-			Step& st = command_utils::getStep(sng, t, order_, s);
-			switch (c) {
-			case 0:		st.clearNoteNumber();		break;
-			case 1:		st.clearInstrumentNumber();	break;
-			case 2:		st.clearVolume();			break;
-			default:
-			{
-				int ec = c - 3;
-				int ei = ec / 2;
-				if (ec % 2) st.clearEffectValue(ei);
-				else st.clearEffectId(ei);
+	for (; stepIndex <= eStep_; ++stepIndex) {
+		int trackIndex = bTrack_;
+		int columnIndex = bCol_;
+
+		for (std::size_t j = 0; j < prevCells_.columnSize(); ++j) {
+			Step& step = command_utils::getStep(song, trackIndex, order_, stepIndex);
+
+			switch (columnIndex) {
+			case 0:
+				step.clearNoteNumber();
+				break;
+
+			case 1:
+				step.clearInstrumentNumber();
+				break;
+
+			case 2:
+				step.clearVolume();
+				break;
+
+			default: {
+				int effectColumnIndex = columnIndex - 3;
+				int effectNumber = effectColumnIndex / 2;
+				if (effectColumnIndex % 2) {
+					// Effect value column.
+					step.clearEffectValue(effectNumber);
+				}
+				else {
+					// Effect ID number.
+					step.clearEffectId(effectNumber);
+				}
 				break;
 			}
 			}
 
-			t += (++c / Step::N_COLUMN);
-			c %= Step::N_COLUMN;
+			trackIndex += (++columnIndex / Step::N_COLUMN);
+			columnIndex %= Step::N_COLUMN;
 		}
 	}
+
+	return true;
 }
 
-void ShrinkPatternCommand::undo()
+bool ShrinkPatternCommand::undo()
 {
-	command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, bTrack_, bCol_, order_, bStep_);
+	try {
+		command_utils::restorePattern(mod_.lock()->getSong(song_), prevCells_, bTrack_, bCol_, order_, bStep_);
+		return true;
+	}
+	catch (...) {
+		return false;
+	}
+
 }

--- a/BambooTracker/command/pattern/shrink_pattern_command.hpp
+++ b/BambooTracker/command/pattern/shrink_pattern_command.hpp
@@ -1,35 +1,15 @@
 /*
- * Copyright (C) 2018-2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <string>
 #include "../abstract_command.hpp"
 #include "module.hpp"
+#include "vector_2d.hpp"
 
 class ShrinkPatternCommand final : public AbstractCommand
 {
@@ -37,12 +17,12 @@ public:
 	ShrinkPatternCommand(std::weak_ptr<Module> mod, int songNum,
 						 int beginTrack, int beginColumn, int beginOrder, int beginStep,
 						 int endTrack, int endColumn, int endStep);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;
 	int song_, bTrack_, bCol_, order_, bStep_;
 	int eStep_;
-	std::vector<std::vector<std::string>> prevCells_;
+	Vector2d<std::string> prevCells_;
 };

--- a/BambooTracker/command/pattern/transpose_note_in_pattern_command.cpp
+++ b/BambooTracker/command/pattern/transpose_note_in_pattern_command.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2020-2021 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2020 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "transpose_note_in_pattern_command.hpp"
@@ -51,7 +31,7 @@ TransposeNoteInPatternCommand::TransposeNoteInPatternCommand(
 	}
 }
 
-void TransposeNoteInPatternCommand::redo()
+bool TransposeNoteInPatternCommand::redo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 
@@ -64,9 +44,10 @@ void TransposeNoteInPatternCommand::redo()
 			}
 		}
 	}
+	return true;
 }
 
-void TransposeNoteInPatternCommand::undo()
+bool TransposeNoteInPatternCommand::undo()
 {
 	auto& sng = mod_.lock()->getSong(song_);
 
@@ -77,4 +58,5 @@ void TransposeNoteInPatternCommand::undo()
 			if (st.hasGeneralNote()) st.setNoteNumber(prevKeys_.at(i++));
 		}
 	}
+	return true;
 }

--- a/BambooTracker/command/pattern/transpose_note_in_pattern_command.hpp
+++ b/BambooTracker/command/pattern/transpose_note_in_pattern_command.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2020 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2020 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -36,8 +16,8 @@ public:
 	TransposeNoteInPatternCommand(std::weak_ptr<Module> mod, int songNum,
 								  int beginTrack, int beginOrder, int beginStep,
 								  int endTrack, int endStep, int semitone);
-	void redo() override;
-	void undo() override;
+	bool redo() override;
+	bool undo() override;
 
 private:
 	std::weak_ptr<Module> mod_;

--- a/BambooTracker/gui/command_result_message_box.hpp
+++ b/BambooTracker/gui/command_result_message_box.hpp
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Rerrah
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <QMessageBox>
+
+namespace command_result_message_box
+{
+inline void showCommandInvokingErrorMessageBox(QWidget* parent)
+{
+	QMessageBox::critical(parent, QMessageBox::tr("Error"),
+						  QMessageBox::tr("Failed to execute the command."),
+						  QMessageBox::Ok, QMessageBox::Ok);
+}
+
+inline void showCommandRedoingErrorMessageBox(QWidget* parent)
+{
+	QMessageBox::critical(parent, QMessageBox::tr("Error"),
+						  QMessageBox::tr("Failed to redo the command."),
+						  QMessageBox::Ok, QMessageBox::Ok);
+}
+
+inline void showCommandUndoingErrorMessageBox(QWidget* parent)
+{
+	QMessageBox::critical(parent, QMessageBox::tr("Error"),
+						  QMessageBox::tr("Failed to undo the command."),
+						  QMessageBox::Ok, QMessageBox::Ok);
+}
+}

--- a/BambooTracker/gui/mainwindow.cpp
+++ b/BambooTracker/gui/mainwindow.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2023 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "mainwindow.hpp"
@@ -86,6 +66,7 @@
 #include "gui/file_io_error_message_box.hpp"
 #include "gui/note_name_manager.hpp"
 #include "gui/gui_utils.hpp"
+#include "gui/command_result_message_box.hpp"
 #include "utils.hpp"
 
 namespace
@@ -2096,13 +2077,19 @@ void MainWindow::swapInstruments(int row1, int row2)
 /********** Undo-Redo **********/
 void MainWindow::undo()
 {
-	bt_->undo();
+	if (!bt_->undo()) {
+		command_result_message_box::showCommandUndoingErrorMessageBox(this);
+		return;
+	}
 	comStack_->undo();
 }
 
 void MainWindow::redo()
 {
-	bt_->redo();
+	if (!bt_->redo()) {
+		command_result_message_box::showCommandRedoingErrorMessageBox(this);
+		return;
+	}
 	comStack_->redo();
 }
 
@@ -3111,7 +3098,7 @@ void MainWindow::on_actionAbout_triggered()
 {
 	static const QString APP_NAME = "BambooTracker v" + QString::fromStdString(Version::ofApplicationInString());
 	static const QString APP_DESC = tr("YM2608 Music Tracker");
-	static constexpr char COPY[] = "Copyright (C) 2018-2024 Rerrah";
+	static constexpr char COPY[] = "Copyright (C) 2018 Rerrah";
 	static const QString WEB = tr("Web:")
 							   + R"( <a href="https://bambootracker.github.io/BambooTracker/">https://bambootracker.github.io/BambooTracker/</a>)";
 

--- a/BambooTracker/gui/pattern_editor/pattern_editor_panel.hpp
+++ b/BambooTracker/gui/pattern_editor/pattern_editor_panel.hpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2022 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #ifndef PATTERN_EDITOR_PANEL_HPP
@@ -47,6 +27,7 @@
 #include "bamboo_tracker.hpp"
 #include "configuration.hpp"
 #include "song.hpp"
+#include "vector_2d.hpp"
 #include "gui/pattern_editor/pattern_position.hpp"
 #include "gui/color_palette.hpp"
 
@@ -300,11 +281,9 @@ private:
 	void pasteMixCopiedCells(const PatternPosition& cursorPos);
 	void pasteOverwriteCopiedCells(const PatternPosition& cursorPos);
 	void pasteInsertCopiedCells(const PatternPosition& cursorPos);
-	using PatternCells = std::vector<std::vector<std::string>>;
-	PatternCells decodeCells(QString str, int& startCol);
 	PatternPosition getPasteLeftAbovePosition(
 			int pasteCol, const PatternPosition& cursorPos, size_t cellW) const;
-	PatternCells compandPasteCells(const PatternPosition& laPos, const PatternCells& cells);
+	Vector2d<std::string> makeCopiedCellsForPasteFull(const PatternPosition& laPos, const Vector2d<std::string>& cells);
 
 	void transposeNote(const PatternPosition& startPos, const PatternPosition& endPos, int semitone);
 	void changeValuesInPattern(const PatternPosition& startPos, const PatternPosition& endPos, int value);

--- a/BambooTracker/vector_2d.hpp
+++ b/BambooTracker/vector_2d.hpp
@@ -1,0 +1,178 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Rerrah
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+template <typename T>
+class Vector2d
+{
+public:
+	using row_type = typename std::vector<T>;
+
+private:
+	using content_type = std::vector<row_type>;
+
+public:
+	using size_type = typename content_type::size_type;
+	using reference = typename content_type::reference;
+	using const_reference = typename content_type::const_reference;
+	using iterator = typename content_type::iterator;
+	using const_iterator = typename content_type::const_iterator;
+	using value_type = typename content_type::value_type;
+
+	/**
+	 * @brief Create an empty 2D-vector.
+	 */
+	Vector2d() noexcept {}
+
+	Vector2d(size_type row, size_type column)
+	{
+		for (size_type i = 0; i < row; ++i) {
+			vector_.emplace_back(column);
+		}
+	}
+
+	Vector2d(const std::pair<size_type, size_type>& shape)
+		: Vector2d(shape.first, shape.second) {}
+
+	Vector2d(size_type row, size_type column, const T& value)
+	{
+		for (size_type i = 0; i < row; ++i) {
+			vector_.emplace_back(column, value);
+		}
+	}
+
+	Vector2d(const std::pair<size_type, size_type> shape, const T& value)
+		: Vector2d(shape.first, shape.second, value) {}
+
+	Vector2d(size_type row, size_type column, const row_type& values)
+	{
+		for (size_type i = 0; i < row; ++i) {
+			vector_.emplace_back(values.begin() + i * column, values.begin() + (i + 1) * column);
+		}
+	}
+
+	Vector2d(const std::pair<size_type, size_type>& shape, const row_type& values)
+		: Vector2d(shape.first, shape.second, values) {}
+
+	/**
+	 * @return @c true when there are no rows with different number of columns.
+	 */
+	bool isValid() const
+	{
+		return std::all_of(vector_.cbegin() + 1, vector_.cend(), [colSize = columnSize()](const_reference row) { return row.size() == colSize; });
+	}
+
+	bool empty() const
+	{
+		return rowSize() == 0 && columnSize() == 0;
+	}
+
+	std::pair<size_type, size_type> shape() const
+	{
+		return { rowSize(), columnSize() };
+	}
+
+	size_type rowSize() const
+	{
+		return vector_.size();
+	}
+
+	size_type columnSize() const
+	{
+		return vector_.empty() ? 0 : vector_.front().size();
+	}
+
+	reference operator[](size_type n)
+	{
+		return vector_[n];
+	}
+
+	const_reference operator[](size_type n) const
+	{
+		return vector_[n];
+	}
+
+	reference at(size_type n)
+	{
+		return vector_.at(n);
+	}
+
+	const_reference at(size_type n) const
+	{
+		return vector_.at(n);
+	}
+
+	reference at(size_type row, size_type column)
+	{
+		return vector_.at(row).at(column);
+	}
+
+	const_reference at(size_type row, size_type column) const
+	{
+		return vector_.at(row).at(column);
+	}
+
+	iterator begin()
+	{
+		return vector_.begin();
+	}
+
+	const_iterator begin() const
+	{
+		return vector_.begin();
+	}
+
+	iterator end()
+	{
+		return vector_.end();
+	}
+
+	const_iterator end() const
+	{
+		return vector_.end();
+	}
+
+	const_iterator cbegin() const
+	{
+		return vector_.cbegin();
+	}
+
+	const_iterator cend() const
+	{
+		return vector_.cend();
+	}
+
+	Vector2d<T> clip(size_type beginRow, size_type beginColumn, size_type rowSize, size_type columnSize) const
+	{
+		size_type clippedbeginRow = std::min(beginRow, this->rowSize());
+		size_type clippedbeginColumn = std::min(beginColumn, this->columnSize());
+
+		size_type clippedEndRow = std::min(beginRow + rowSize, this->rowSize());
+		size_type clippedEndColumn = std::min(beginColumn + columnSize, this->columnSize());
+
+		size_type clippedRowSize = clippedEndRow - clippedbeginRow;
+		size_type clippedColumnSize = clippedEndColumn - clippedbeginColumn;
+
+		Vector2d<T> newData;
+		for (size_type i = 0; i < clippedRowSize; ++i) {
+			const auto copiedBeginIter = vector_[clippedbeginRow + i].begin() + clippedbeginColumn;
+			newData.vector_.emplace_back(copiedBeginIter, copiedBeginIter + clippedColumnSize);
+		}
+
+		return newData;
+	}
+
+	Vector2d<T> clip(size_type beginRow, size_type beginColumn, std::pair<size_type, size_type> shape) const
+	{
+		return clip(beginRow, beginColumn, shape.first, shape.second);
+	}
+
+private:
+	content_type vector_;
+};


### PR DESCRIPTION
Fix #523.

All commands return undoing or redoing result as a boolean value. When undoing or redoing is failed, the operation is rollbacked and an error message box is displayed.

I also improved error handlings for paste commands to prevent the application from crasing when the clipboard contains invalid data.