### PR TITLE
Use Ubuntu 22.04 GHA runner image

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Identify build type.
@@ -72,7 +72,7 @@ jobs:
       - name: Installing dependencies.
         run: |
           sudo apt update
-          sudo apt install qt5-default qttools5-dev-tools \
+          sudo apt install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools qttools5-dev-tools \
             libasound2-dev libpulse-dev libjack-jackd2-dev
 
       ## End Ubuntu-specific steps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#516] - Replace instrument numbers in all songs on "Reflect Instrument Number Change" ([#515]; thanks [@Esmerea])
 - [#517] - Raise macOS version of GitHub Actions workflow to 13
 - [#522] - README: Change repology badge to 3 columns (thanks [@luzpaz])
+- [#525] - Use Ubuntu 22.04 GHA runner image
 
 ### Fixed
 
@@ -29,6 +30,7 @@
 [#522]: https://github.com/BambooTracker/BambooTracker/pull/522
 [#523]: https://github.com/BambooTracker/BambooTracker/issues/523
 [#524]: https://github.com/BambooTracker/BambooTracker/pull/524
+[#525]: https://github.com/BambooTracker/BambooTracker/pull/525
 
 ## v0.6.4 (2024-09-24)
 


### PR DESCRIPTION
[Ubuntu 20.04 image for GHA will be deprecated](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#ubuntu-20-image-is-closing-down), so we need to update image to 22.04.