### PR TITLE
Fix auto envelope effect to reset phase after period change

### DIFF
--- a/BambooTracker/opna_controller.cpp
+++ b/BambooTracker/opna_controller.cpp
@@ -1,26 +1,6 @@
 /*
- * Copyright (C) 2018-2023 Rerrah
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2018 Rerrah
+ * SPDX-License-Identifier: MIT
  */
 
 #include "opna_controller.hpp"
@@ -2398,7 +2378,6 @@ void OPNAController::setAutoEnvelopeSSG(int ch, int shift, int shape)
 {
 	auto& ssg = ssg_[ch];
 	if (shape) {
-		opna_->setRegister(0x0d, static_cast<uint8_t>(shape));
 		int d = AUTO_ENV_SHAPE_TYPE[shape - 1];
 		if (!ssg.isMute) opna_->setRegister(0x08 + ssg.ch, 0x10);
 		ssg.isHardEnv = true;
@@ -2414,6 +2393,9 @@ void OPNAController::setAutoEnvelopeSSG(int ch, int shift, int shape)
 			ssg.shouldSetEnv = true;
 			ssg.shouldSetHardEnvFreq = true;
 		}
+
+		// Reset phase
+		opna_->setRegister(0x0d, static_cast<uint8_t>(shape));
 	}
 	else {
 		ssg.isHardEnv = false;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - [#524] - Improve error handling on undo/redo ([#523]; thanks [@brickblock369])
+- [#526] - Fix auto envelope effect to reset phase after period change
 
 [@grayedsol]: https://github.com/grayedsol
 [@Esmerea]: https://github.com/Esmerea
@@ -31,6 +32,7 @@
 [#523]: https://github.com/BambooTracker/BambooTracker/issues/523
 [#524]: https://github.com/BambooTracker/BambooTracker/pull/524
 [#525]: https://github.com/BambooTracker/BambooTracker/pull/525
+[#526]: https://github.com/BambooTracker/BambooTracker/pull/526
 
 ## v0.6.4 (2024-09-24)
 


### PR DESCRIPTION
Report from Discord: When `0H0y` (auto envelope effect) is activated before `0Ixx` or `0Jxx` (hardware envelope period effect) is set, it is not work well to reset the phase of hardware envelope. This causes This causes the hardware envelope not to start at the intended timing.

This is fixed by execute `0Hxx` effect after `0Ixx` and `0Jxx` effects internally.