### PR TITLE
BambooTracker/instrument/instrument_property_defs.hpp: Fix compilation on GCC 15

### DIFF
--- a/BambooTracker/instrument/instrument_property_defs.hpp
+++ b/BambooTracker/instrument/instrument_property_defs.hpp
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "sequence_property.hpp"
 
 using FMOperatorSequenceUnit = InstrumentSequenceBaseUnit;


### PR DESCRIPTION
Closes #527

When building on Fedora rawhide, I still need to set some `-Wno-error` flags to get the build to work, but this at least resolves the reported part of the FTBFS on my end.

CC @ycollet, could you test this? You may also have to uncomment `CPP_WARNING_FLAGS` in `/BambooTracker/BambooTracker.pro` and add `-Wno-error=deprecated-declarations -Wno-error=redundant-move` for the build to complete for now (I'll look into those next).