### PR TITLE
Fix compiler warnings on Fedora rawhide

### DIFF
--- a/BambooTracker/gui/instrument_editor/fm_instrument_editor.cpp
+++ b/BambooTracker/gui/instrument_editor/fm_instrument_editor.cpp
@@ -277,8 +277,14 @@ FmInstrumentEditor::FmInstrumentEditor(int num, QWidget* parent) :
 		}
 	});
 
-	QObject::connect(ui->amOp1CheckBox, &QCheckBox::stateChanged,
-					 this, [&](int state) {
+	QObject::connect(ui->amOp1CheckBox,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+					&QCheckBox::checkStateChanged,
+					this, [&](Qt::CheckState state) {
+#else
+					&QCheckBox::stateChanged,
+					this, [&](int state) {
+#endif
 		if (!isIgnoreEvent_) {
 			bt_.lock()->setLFOFMParameter(ui->lfoNumSpinBox->value(), FMLFOParameter::AM1,
 										  (state == Qt::Checked) ? 1 : 0);
@@ -286,8 +292,14 @@ FmInstrumentEditor::FmInstrumentEditor(int num, QWidget* parent) :
 			emit modified();
 		}
 	});
-	QObject::connect(ui->amOp2CheckBox, &QCheckBox::stateChanged,
-					 this, [&](int state) {
+	QObject::connect(ui->amOp2CheckBox,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+					&QCheckBox::checkStateChanged,
+					this, [&](Qt::CheckState state) {
+#else
+					&QCheckBox::stateChanged,
+					this, [&](int state) {
+#endif
 		if (!isIgnoreEvent_) {
 			bt_.lock()->setLFOFMParameter(ui->lfoNumSpinBox->value(), FMLFOParameter::AM2,
 										  (state == Qt::Checked) ? 1 : 0);
@@ -295,8 +307,14 @@ FmInstrumentEditor::FmInstrumentEditor(int num, QWidget* parent) :
 			emit modified();
 		}
 	});
-	QObject::connect(ui->amOp3CheckBox, &QCheckBox::stateChanged,
-					 this, [&](int state) {
+	QObject::connect(ui->amOp3CheckBox,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+					&QCheckBox::checkStateChanged,
+					this, [&](Qt::CheckState state) {
+#else
+					&QCheckBox::stateChanged,
+					this, [&](int state) {
+#endif
 		if (!isIgnoreEvent_) {
 			bt_.lock()->setLFOFMParameter(ui->lfoNumSpinBox->value(), FMLFOParameter::AM3,
 										  (state == Qt::Checked) ? 1 : 0);
@@ -304,8 +322,14 @@ FmInstrumentEditor::FmInstrumentEditor(int num, QWidget* parent) :
 			emit modified();
 		}
 	});
-	QObject::connect(ui->amOp4CheckBox, &QCheckBox::stateChanged,
-					 this, [&](int state) {
+	QObject::connect(ui->amOp4CheckBox,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+					&QCheckBox::checkStateChanged,
+					this, [&](Qt::CheckState state) {
+#else
+					&QCheckBox::stateChanged,
+					this, [&](int state) {
+#endif
 		if (!isIgnoreEvent_) {
 			bt_.lock()->setLFOFMParameter(ui->lfoNumSpinBox->value(), FMLFOParameter::AM4,
 										  (state == Qt::Checked) ? 1 : 0);
@@ -685,36 +709,66 @@ FmInstrumentEditor::FmInstrumentEditor(int num, QWidget* parent) :
 	});
 
 	//========== Others ==========//
-	QObject::connect(ui->envResetCheckBox, &QCheckBox::stateChanged,
-					 this, [&](int state) {
+	QObject::connect(ui->envResetCheckBox,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+					&QCheckBox::checkStateChanged,
+					this, [&](Qt::CheckState state) {
+#else
+					&QCheckBox::stateChanged,
+					this, [&](int state) {
+#endif
 		if (!isIgnoreEvent_) {
 			bt_.lock()->setInstrumentFMEnvelopeResetEnabled(instNum_, FMOperatorType::All, (state == Qt::Checked));
 			emit modified();
 		}
 	});
-	QObject::connect(ui->envResetOp1CheckBox, &QCheckBox::stateChanged,
-					 this, [&](int state) {
+	QObject::connect(ui->envResetOp1CheckBox,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+					&QCheckBox::checkStateChanged,
+					this, [&](Qt::CheckState state) {
+#else
+					&QCheckBox::stateChanged,
+					this, [&](int state) {
+#endif
 		if (!isIgnoreEvent_) {
 			bt_.lock()->setInstrumentFMEnvelopeResetEnabled(instNum_, FMOperatorType::Op1, (state == Qt::Checked));
 			emit modified();
 		}
 	});
-	QObject::connect(ui->envResetOp2CheckBox, &QCheckBox::stateChanged,
-					 this, [&](int state) {
+	QObject::connect(ui->envResetOp2CheckBox,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+					&QCheckBox::checkStateChanged,
+					this, [&](Qt::CheckState state) {
+#else
+					&QCheckBox::stateChanged,
+					this, [&](int state) {
+#endif
 		if (!isIgnoreEvent_) {
 			bt_.lock()->setInstrumentFMEnvelopeResetEnabled(instNum_, FMOperatorType::Op2, (state == Qt::Checked));
 			emit modified();
 		}
 	});
-	QObject::connect(ui->envResetOp3CheckBox, &QCheckBox::stateChanged,
-					 this, [&](int state) {
+	QObject::connect(ui->envResetOp3CheckBox,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+					&QCheckBox::checkStateChanged,
+					this, [&](Qt::CheckState state) {
+#else
+					&QCheckBox::stateChanged,
+					this, [&](int state) {
+#endif
 		if (!isIgnoreEvent_) {
 			bt_.lock()->setInstrumentFMEnvelopeResetEnabled(instNum_, FMOperatorType::Op3, (state == Qt::Checked));
 			emit modified();
 		}
 	});
-	QObject::connect(ui->envResetOp4CheckBox, &QCheckBox::stateChanged,
-					 this, [&](int state) {
+	QObject::connect(ui->envResetOp4CheckBox,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+					&QCheckBox::checkStateChanged,
+					this, [&](Qt::CheckState state) {
+#else
+					&QCheckBox::stateChanged,
+					this, [&](int state) {
+#endif
 		if (!isIgnoreEvent_) {
 			bt_.lock()->setInstrumentFMEnvelopeResetEnabled(instNum_, FMOperatorType::Op4, (state == Qt::Checked));
 			emit modified();

--- a/BambooTracker/playback.cpp
+++ b/BambooTracker/playback.cpp
@@ -39,9 +39,8 @@ void EffectMemory::enqueue(const Effect& eff)
 			return;
 		}
 
-		auto autoEnv = std::move(*autoEnvItr);
 		mem_.erase(autoEnvItr);
-		mem_.push_back(std::move(autoEnv));
+		mem_.push_back(std::move(*autoEnvItr));
 		break;
 	}
 


### PR DESCRIPTION
1. `redundant-move`: Should be self-explanatory.
    ```
    g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -Wall -Wextra -pedantic -Werror -pedantic-errors -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -Iinstrument -Imodule -I../submodules/emu2149/src -I../submodules/RtAudio/src -I../submodules/RtMidi/src -I/usr/include/qt6 -I/usr/include/qt6/QtWidgets -I/usr/include/qt6/QtGui -I/usr/include/qt6/QtCore5Compat -I/usr/include/qt6/QtCore -I. -I. -I/usr/lib64/qt6/mkspecs/linux-g++ -o playback.o playback.cpp
    playback.cpp: In member function 'void EffectMemory::enqueue(const Effect&)':
    playback.cpp:42:41: error: redundant move in initialization [-Werror=redundant-move]
       42 |                 auto autoEnv = std::move(*autoEnvItr);
          |                                ~~~~~~~~~^~~~~~~~~~~~~
    playback.cpp:42:41: note: remove 'std::move' call
    ```

2. `deprecated-declarations`: Qt 6.7 added `QCheckBox::checkStateChanged(Qt::CheckState)` to replace `QCheckBox::stateChanged(int)`. Decide which to use based on the Qt version.
    ```
    g++ -c -pipe -g -std=gnu++1z -Wall -Wextra -Wall -Wextra -pedantic -Werror -pedantic-errors -D_REENTRANT -DQT_DEPRECATED_WARNINGS -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -Iinstrument -Imodule -I../submodules/emu2149/src -I../submodules/RtAudio/src -I../submodules/RtMidi/src -I/usr/include/qt6 -I/usr/include/qt6/QtWidgets -I/usr/include/qt6/QtGui -I/usr/include/qt6/QtCore5Compat -I/usr/include/qt6/QtCore -I. -I. -I/usr/lib64/qt6/mkspecs/linux-g++ -o fm_instrument_editor.o gui/instrument_editor/fm_instrument_editor.cpp
    gui/instrument_editor/fm_instrument_editor.cpp: In constructor 'FmInstrumentEditor::FmInstrumentEditor(int, QWidget*)':
    gui/instrument_editor/fm_instrument_editor.cpp:280:57: error: 'void QCheckBox::stateChanged(int)' is deprecated: Use checkStateChanged() instead [-Werror=deprecated-declarations]
      280 |         QObject::connect(ui->amOp1CheckBox, &QCheckBox::stateChanged,
          |                                                         ^~~~~~~~~~~~
    In file included from /usr/include/qt6/QtWidgets/QCheckBox:1,
                     from ./ui_fm_instrument_editor.h:14,
                     from gui/instrument_editor/fm_instrument_editor.cpp:27:
    /usr/include/qt6/QtWidgets/qcheckbox.h:41:10: note: declared here
       41 |     void stateChanged(int);
          |          ^~~~~~~~~~~~
    ```

Resulting binary is untested, but changes look fine to me on paper.

CC @ycollet, with this second set of changes, in addition to #528, the build should finish without further errors. Can you confirm this on your end?