### PR TITLE
command/instrument/swap_instruments_command*: Drop unused property

### DIFF
--- a/BambooTracker/bamboo_tracker.cpp
+++ b/BambooTracker/bamboo_tracker.cpp
@@ -161,7 +161,7 @@ void BambooTracker::deepCloneInstrument(int num, int refNum)
 
 void BambooTracker::swapInstruments(int a, int b, bool patternChange)
 {
-	comMan_.invoke(std::make_unique<SwapInstrumentsCommand>(instMan_, mod_, a, b, curSongNum_, patternChange));
+	comMan_.invoke(std::make_unique<SwapInstrumentsCommand>(instMan_, mod_, a, b, patternChange));
 }
 
 void BambooTracker::loadInstrument(io::BinaryContainer& container, const std::string& path, int instNum)

--- a/BambooTracker/command/instrument/swap_instruments_command.cpp
+++ b/BambooTracker/command/instrument/swap_instruments_command.cpp
@@ -7,13 +7,12 @@
 
 SwapInstrumentsCommand::SwapInstrumentsCommand(std::weak_ptr<InstrumentsManager> manager,
 											   std::weak_ptr<Module> mod, int inst1, int inst2,
-											   int song, bool patternChange)
+											   bool patternChange)
 	: AbstractCommand(CommandId::SwapInstruments),
 	  manager_(manager),
 	  mod_(mod),
 	  inst1Num_(inst1),
 	  inst2Num_(inst2),
-	  songNum_(song),
 	  patternChange_(patternChange)
 {
 }

--- a/BambooTracker/command/instrument/swap_instruments_command.hpp
+++ b/BambooTracker/command/instrument/swap_instruments_command.hpp
@@ -14,7 +14,7 @@ class SwapInstrumentsCommand final : public AbstractCommand
 {
 public:
 	SwapInstrumentsCommand(std::weak_ptr<InstrumentsManager> manager, std::weak_ptr<Module> mod,
-						   int inst1, int inst2, int song, bool patternChange);
+						   int inst1, int inst2, bool patternChange);
 	bool redo() override;
 	bool undo() override;
 
@@ -22,7 +22,6 @@ private:
 	std::weak_ptr<InstrumentsManager> manager_;
 	std::weak_ptr<Module> mod_;
 	int inst1Num_, inst2Num_;
-	int songNum_;
 	bool patternChange_;
 
 	void swapInstrumentsInPatterns();


### PR DESCRIPTION
```
clang++ -c -pipe -O2 -std=gnu++1z -pthread -pthread -Wall -Wextra -Wall -Wextra -pedantic -Werror -pedantic-errors -fPIC -D_REENTRANT -DQT_DEPRECATED_WARNINGS -D__UNIX_JACK__ -D__LINUX_ALSA__ -D__LINUX_PULSE__ -DJACK_HAS_PORT_RENAME -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -I. -Iinstrument -Imodule -I../submodules/emu2149/src -I/nix/store/8p6c5chsl23lx8453b7x3yzyyi28rnq7-rtaudio-6.0.1/include/rtaudio -I/nix/store/swq3ikcdhjvvzprj4w54bwmps2akrg3z-rtmidi-5.0.0/include/rtmidi -I/nix/store/00dn0wh9afy98xja69p7i404jgznfkdk-qtbase-6.8.2/include/QtWidgets -I/nix/store/00dn0wh9afy98xja69p7i404jgznfkdk-qtbase-6.8.2/include/QtGui -I/nix/store/bj3843hrcw8yf73hgp853690b17bci9n-qt5compat-6.8.2/include/QtCore5Compat -I/nix/store/00dn0wh9afy98xja69p7i404jgznfkdk-qtbase-6.8.2/include/QtCore -I. -I. -I/nix/store/00dn0wh9afy98xja69p7i404jgznfkdk-qtbase-6.8.2/mkspecs/linux-clang -o swap_instruments_command.o command/instrument/swap_instruments_command.cpp
In file included from command/instrument/swap_instruments_command.cpp:6:
command/instrument/swap_instruments_command.hpp:25:6: error: private field 'songNum_' is not used [-Werror,-Wunused-private-field]
   25 |         int songNum_;
      |             ^
1 error generated.
```

`songNum_` is set, but never used for anything, so Clang warns about it being unused.

There's still more warnings that Darwin CI runs into, which may or may not be specific to Apple's LLVM, but this should at least resolve all warnings when building with Clang on Linux (without using libcxx).