### PR TITLE
BambooTracker/utils.hpp: Migrate std::result_of -> std::invoke_result

### DIFF
--- a/BambooTracker/utils.hpp
+++ b/BambooTracker/utils.hpp
@@ -72,8 +72,7 @@ template <template <typename ...> class OutputContainer = std::vector,
 		  class InputContainer, class UnaryOperation>
 inline auto transform(InputContainer& input, UnaryOperation&& op)
 {
-	// std::result_of is deprecated in C++17 and obsoluted in C++20, use std::invoke_result after C++14
-	using T = typename std::result_of<UnaryOperation&&(typename InputContainer::value_type)>::type;
+	using T = typename std::invoke_result<UnaryOperation&&,typename InputContainer::value_type>::type;
 	OutputContainer<T> output;
 	std::transform(input.begin(), input.end(), std::back_inserter(output), op);
 	return output;
@@ -92,8 +91,7 @@ template <template <typename ...> class OutputContainer = std::vector,
 		  class InputContainer, class Predicate, class UnaryOperation>
 inline auto transformIf(const InputContainer& input, Predicate&& pred, UnaryOperation&& op)
 {
-	// std::result_of is deprecated in C++17 and obsoluted in C++20, use std::invoke_result after C++14
-	using T = typename std::result_of<UnaryOperation&&(typename InputContainer::value_type)>::type;
+	using T = typename std::invoke_result<UnaryOperation&&,typename InputContainer::value_type>::type;
 	OutputContainer<T> output;
 	transformIf(input.begin(), input.end(), std::back_inserter(output), pred, op);
 	return output;


### PR DESCRIPTION
Closes #506 (LLVM shouldn't complain about deprecated C++ features anymore)
Closes #518 (Shouldn't be necessary anymore)

We request C++17, which deprecates `std::result_of`. In C++20, it's supposed to be gone. LLVM's libc++ is very strict about this, and emits a warning, which turns into an error with our flags.