### PR TITLE
Update ymfm

### DIFF
--- a/BambooTracker/chip/ymfm/ymfm_fm.h
+++ b/BambooTracker/chip/ymfm/ymfm_fm.h
@@ -33,10 +33,11 @@
 
 #pragma once
 
+/*[BambooTracker] Add headers*/
 #include <cstdint>
 #include "ymfm.h"
 
-#define DEBUG_LOG_WAVFILES (0)
+#define YMFM_DEBUG_LOG_WAVFILES (0)
 
 namespace ymfm
 {
@@ -270,7 +271,7 @@ public:
 	// assign operators
 	void assign(uint32_t index, fm_operator<RegisterType> *op)
 	{
-		assert(index < array_size(m_op));
+		assert(index < m_op.size());
 		m_op[index] = op;
 		if (op != nullptr)
 			op->set_choffs(m_choffs);
@@ -290,7 +291,7 @@ public:
 	void output_4op(output_data &output, uint32_t rshift, int32_t clipmax) const;
 
 	// compute the special OPL rhythm channel outputs
-	void output_rhythm_ch6(output_data &output, uint32_t rshift, int32_t clipmax) const;
+	void output_rhythm_ch6(output_data &output, uint32_t rshift, int32_t /*clipmax*/) const;
 	void output_rhythm_ch7(uint32_t phase_select, output_data &output, uint32_t rshift, int32_t clipmax) const;
 	void output_rhythm_ch8(uint32_t phase_select, output_data &output, uint32_t rshift, int32_t clipmax) const;
 
@@ -333,7 +334,7 @@ private:
 	uint32_t m_choffs;                     // channel offset in registers
 	int16_t m_feedback[2];                 // feedback memory for operator 1
 	mutable int16_t m_feedback_in;         // next input value for op 1 feedback (set in output)
-	fm_operator<RegisterType> *m_op[4];    // up to 4 operators
+	std::array<fm_operator<RegisterType> *, 4> m_op; // up to 4 operators
 	RegisterType &m_regs;                  // direct reference to registers
 	fm_engine_base<RegisterType> &m_owner; // reference to the owning engine
 };
@@ -404,7 +405,7 @@ public:
 	// compute sample rate
 	uint32_t sample_rate(uint32_t baseclock) const
 	{
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 		for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
 			m_wavfile[chnum].set_samplerate(baseclock / (m_clock_prescale * OPERATORS));
 #endif
@@ -456,7 +457,7 @@ protected:
 	RegisterType m_regs;             // register accessor
 	std::unique_ptr<fm_channel<RegisterType>> m_channel[CHANNELS]; // channel pointers
 	std::unique_ptr<fm_operator<RegisterType>> m_operator[OPERATORS]; // operator pointers
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 	mutable ymfm_wavfile<1> m_wavfile[CHANNELS]; // for debugging
 #endif
 };

--- a/BambooTracker/chip/ymfm/ymfm_fm.ipp
+++ b/BambooTracker/chip/ymfm/ymfm_fm.ipp
@@ -839,12 +839,12 @@ void fm_channel<RegisterType>::save_restore(ymfm_saved_state &state)
 template<class RegisterType>
 void fm_channel<RegisterType>::keyonoff(uint32_t states, keyon_type type, uint32_t chnum)
 {
-	for (uint32_t opnum = 0; opnum < array_size(m_op); opnum++)
+	for (uint32_t opnum = 0; opnum < m_op.size(); opnum++)
 		if (m_op[opnum] != nullptr)
 			m_op[opnum]->keyonoff(bitfield(states, opnum), type);
 
 	if (debug::LOG_KEYON_EVENTS && ((debug::GLOBAL_FM_CHANNEL_MASK >> chnum) & 1) != 0)
-		for (uint32_t opnum = 0; opnum < array_size(m_op); opnum++)
+		for (uint32_t opnum = 0; opnum < m_op.size(); opnum++)
 			if (m_op[opnum] != nullptr)
 				debug::log_keyon("%c%s\n", bitfield(states, opnum) ? '+' : '-', m_regs.log_keyon(m_choffs, m_op[opnum]->opoffs()).c_str());
 }
@@ -860,7 +860,7 @@ bool fm_channel<RegisterType>::prepare()
 	uint32_t active_mask = 0;
 
 	// prepare all operators and determine if they are active
-	for (uint32_t opnum = 0; opnum < array_size(m_op); opnum++)
+	for (uint32_t opnum = 0; opnum < m_op.size(); opnum++)
 		if (m_op[opnum] != nullptr)
 			if (m_op[opnum]->prepare())
 				active_mask |= 1 << opnum;
@@ -880,7 +880,7 @@ void fm_channel<RegisterType>::clock(uint32_t env_counter, int32_t lfo_raw_pm)
 	m_feedback[0] = m_feedback[1];
 	m_feedback[1] = m_feedback_in;
 
-	for (uint32_t opnum = 0; opnum < array_size(m_op); opnum++)
+	for (uint32_t opnum = 0; opnum < m_op.size(); opnum++)
 		if (m_op[opnum] != nullptr)
 			m_op[opnum]->clock(env_counter, lfo_raw_pm);
 
@@ -888,7 +888,7 @@ void fm_channel<RegisterType>::clock(uint32_t env_counter, int32_t lfo_raw_pm)
 useful temporary code for envelope debugging
 if (m_choffs == 0x101)
 {
-	for (uint32_t opnum = 0; opnum < array_size(m_op); opnum++)
+	for (uint32_t opnum = 0; opnum < m_op.size(); opnum++)
 	{
 		auto &op = *m_op[((opnum & 1) << 1) | ((opnum >> 1) & 1)];
 		printf(" %c%03X%c%c ",
@@ -1185,6 +1185,7 @@ fm_engine_base<RegisterType>::fm_engine_base(ymfm_interface &intf) :
 	m_irq_mask(STATUS_TIMERA | STATUS_TIMERB),
 	m_irq_state(0),
 	m_timer_running{0,0},
+	m_total_clocks(0),
 	m_active_channels(ALL_CHANNELS),
 	m_modified_channels(ALL_CHANNELS),
 	m_prepare_count(0)
@@ -1200,7 +1201,7 @@ fm_engine_base<RegisterType>::fm_engine_base(ymfm_interface &intf) :
 	for (uint32_t opnum = 0; opnum < OPERATORS; opnum++)
 		m_operator[opnum] = std::make_unique<fm_operator<RegisterType>>(*this, RegisterType::operator_offset(opnum));
 
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 	for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
 		m_wavfile[chnum].set_index(chnum);
 #endif
@@ -1332,7 +1333,7 @@ void fm_engine_base<RegisterType>::output(output_data &output, uint32_t rshift, 
 	chanmask &= debug::GLOBAL_FM_CHANNEL_MASK;
 
 	// mask out inactive channels
-	if (!DEBUG_LOG_WAVFILES)
+	if (!YMFM_DEBUG_LOG_WAVFILES)
 		chanmask &= m_active_channels;
 
 	// handle the rhythm case, where some of the operators are dedicated
@@ -1351,7 +1352,7 @@ void fm_engine_base<RegisterType>::output(output_data &output, uint32_t rshift, 
 		for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
 			if (bitfield(chanmask, chnum))
 			{
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 				auto reference = output;
 #endif
 				if (chnum == 6)
@@ -1364,7 +1365,7 @@ void fm_engine_base<RegisterType>::output(output_data &output, uint32_t rshift, 
 					m_channel[chnum]->output_4op(output, rshift, clipmax);
 				else
 					m_channel[chnum]->output_2op(output, rshift, clipmax);
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 				m_wavfile[chnum].add(output, reference);
 #endif
 			}
@@ -1375,14 +1376,14 @@ void fm_engine_base<RegisterType>::output(output_data &output, uint32_t rshift, 
 		for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
 			if (bitfield(chanmask, chnum))
 			{
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 				auto reference = output;
 #endif
 				if (m_channel[chnum]->is4op())
 					m_channel[chnum]->output_4op(output, rshift, clipmax);
 				else
 					m_channel[chnum]->output_2op(output, rshift, clipmax);
-#if (DEBUG_LOG_WAVFILES)
+#if (YMFM_DEBUG_LOG_WAVFILES)
 				m_wavfile[chnum].add(output, reference);
 #endif
 			}
@@ -1503,6 +1504,8 @@ void fm_engine_base<RegisterType>::update_timer(uint32_t tnum, uint32_t enable, 
 template<class RegisterType>
 void fm_engine_base<RegisterType>::engine_timer_expired(uint32_t tnum)
 {
+	assert(tnum == 0 || tnum == 1);
+
 	// update status
 	if (tnum == 0 && m_regs.enable_timer_a())
 		set_reset_status(STATUS_TIMERA, 0);
@@ -1514,7 +1517,7 @@ void fm_engine_base<RegisterType>::engine_timer_expired(uint32_t tnum)
 		for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
 			if (bitfield(RegisterType::CSM_TRIGGER_MASK, chnum))
 			{
-				m_channel[chnum]->keyonoff(1, KEYON_CSM, chnum);
+				m_channel[chnum]->keyonoff(0xf, KEYON_CSM, chnum);
 				m_modified_channels |= 1 << chnum;
 			}
 

--- a/BambooTracker/chip/ymfm/ymfm_opn.cpp
+++ b/BambooTracker/chip/ymfm/ymfm_opn.cpp
@@ -409,9 +409,9 @@ std::string opn_registers_base<IsOpnA>::log_keyon(uint32_t choffs, uint32_t opof
 	}
 
 	char buffer[256];
-	char *end = &buffer[0];
+	int end = 0;
 
-	end += sprintf(end, "%u.%02u freq=%04X dt=%u fb=%u alg=%X mul=%X tl=%02X ksr=%u adsr=%02X/%02X/%02X/%X sl=%X",
+	end += snprintf(&buffer[end], sizeof(buffer) - end, "%u.%02u freq=%04X dt=%u fb=%u alg=%X mul=%X tl=%02X ksr=%u adsr=%02X/%02X/%02X/%X sl=%X",
 		chnum, opnum,
 		block_freq,
 		op_detune(opoffs),
@@ -427,21 +427,21 @@ std::string opn_registers_base<IsOpnA>::log_keyon(uint32_t choffs, uint32_t opof
 		op_sustain_level(opoffs));
 
 	if (OUTPUTS > 1)
-		end += sprintf(end, " out=%c%c",
+		end += snprintf(&buffer[end], sizeof(buffer) - end, " out=%c%c",
 			ch_output_0(choffs) ? 'L' : '-',
 			ch_output_1(choffs) ? 'R' : '-');
 	if (op_ssg_eg_enable(opoffs))
-		end += sprintf(end, " ssg=%X", op_ssg_eg_mode(opoffs));
+		end += snprintf(&buffer[end], sizeof(buffer) - end, " ssg=%X", op_ssg_eg_mode(opoffs));
 	bool am = (op_lfo_am_enable(opoffs) && ch_lfo_am_sens(choffs) != 0);
 	if (am)
-		end += sprintf(end, " am=%u", ch_lfo_am_sens(choffs));
+		end += snprintf(&buffer[end], sizeof(buffer) - end, " am=%u", ch_lfo_am_sens(choffs));
 	bool pm = (ch_lfo_pm_sens(choffs) != 0);
 	if (pm)
-		end += sprintf(end, " pm=%u", ch_lfo_pm_sens(choffs));
+		end += snprintf(&buffer[end], sizeof(buffer) - end, " pm=%u", ch_lfo_pm_sens(choffs));
 	if (am || pm)
-		end += sprintf(end, " lfo=%02X", lfo_rate());
+		end += snprintf(&buffer[end], sizeof(buffer) - end, " lfo=%02X", lfo_rate());
 	if (multi_freq() && choffs == 2)
-		end += sprintf(end, " multi=1");
+		end += snprintf(&buffer[end], sizeof(buffer) - end, " multi=1");
 
 	return buffer;
 }
@@ -1327,6 +1327,15 @@ void ym2608::write(uint32_t offset, uint8_t data)
 //	m_ssg_resampler.resample(output - numsamples, numsamples);
 //}
 
+
+//-------------------------------------------------
+//  generate_fm_adpcm - generate one sample of sound
+//  for FM and ADPCM
+//  This only work correctly when prescale is set to 6
+//  and output rate is matched to FM synthesis rate
+//-------------------------------------------------
+
+
 /* [BambooTracker]
  * We use only prescale = 6, match output rate to FM synthesis rate */
 void ym2608::generate_fm_adpcm(output_data *output, uint32_t numsamples)
@@ -1339,12 +1348,20 @@ void ym2608::generate_fm_adpcm(output_data *output, uint32_t numsamples)
 	}
 }
 
+
+//-------------------------------------------------
+//  generate_ssg - generate one sample of sound
+//  for SSG
+//  This only work correctly when prescale is set to 6,
+//  and output is not resampled.
+//-------------------------------------------------
+
+
 /* [BambooTracker]
  * We use only prescale = 6 and do not resample SSG */
 void ym2608::generate_ssg(output_data *output, uint32_t numsamples)
 {
-	// TODO
-	// resample the SSG as configured
+	// TODO: resample the SSG as configured
 	m_ssg_resampler.resample(output, numsamples);
 }
 
@@ -1376,7 +1393,9 @@ void ym2608::update_prescale(uint8_t prescale)
 			/* [BambooTracker]
 			 * We use only prescale = 6, match output rate to FM synthesis rate
 			 * and do not resample SSG */
+			// Skip to apply resampler to output separately
 			case 6:	m_fm_samples_per_output = 1;	m_ssg_resampler.configure(1, 1);	break;
+			// case 6:	m_fm_samples_per_output = 3;	m_ssg_resampler.configure(2, 3);	break;
 			case 3: m_fm_samples_per_output = 0;	m_ssg_resampler.configure(1, 3);	break;
 			case 2: m_fm_samples_per_output = 1;	m_ssg_resampler.configure(1, 6);	break;
 		}

--- a/BambooTracker/chip/ymfm/ymfm_opn.h
+++ b/BambooTracker/chip/ymfm/ymfm_opn.h
@@ -141,23 +141,21 @@ public:
 	// map channel number to register offset
 	static constexpr uint32_t channel_offset(uint32_t chnum)
 	{
-		/*assert(chnum < CHANNELS);
+		/*assert(chnum < CHANNELS);*/
 		if (!IsOpnA)
 			return chnum;
 		else
-			return (chnum % 3) + 0x100 * (chnum / 3);*/
-		return (!IsOpnA ? chnum : ((chnum % 3) + 0x100 * (chnum / 3)));
+			return (chnum % 3) + 0x100 * (chnum / 3);
 	}
 
 	// map operator number to register offset
 	static constexpr uint32_t operator_offset(uint32_t opnum)
 	{
-		/*assert(opnum < OPERATORS);
+		/*assert(opnum < OPERATORS);*/
 		if (!IsOpnA)
 			return opnum + opnum / 3;
 		else
-			return (opnum % 12) + ((opnum % 12) / 3) + 0x100 * (opnum / 12);*/
-		return (!IsOpnA ? (opnum + opnum / 3) : ((opnum % 12) + ((opnum % 12) / 3) + 0x100 * (opnum / 12)));
+			return (opnum % 12) + ((opnum % 12) / 3) + 0x100 * (opnum / 12);
 	}
 
 	// return an array of operator indices for each channel
@@ -798,7 +796,7 @@ public:
 	ymf276(ymfm_interface &intf) : ym2612(intf) { }
 
 	// generate one sample of sound
-	void generate(output_data *output, uint32_t numsamples);
+	void generate(output_data *output, uint32_t numsamples = 1);
 };
 #endif
 }

--- a/BambooTracker/chip/ymfm/ymfm_ssg.h
+++ b/BambooTracker/chip/ymfm/ymfm_ssg.h
@@ -49,6 +49,8 @@ namespace ymfm
 class ssg_override
 {
 public:
+	virtual ~ssg_override() = default;
+
 	// reset our status
 	virtual void ssg_reset() = 0;
 


### PR DESCRIPTION
There were some modifications in the original source that were not reflected in BT. This caused clang compile warnings and other problems.

Based on rerrahkr/ymfm@8a6767c, I modified files to correspond to the latest commit. The warnings should now disappear.